### PR TITLE
[Feat] 현재 날씨 및 쉼터 리스트 작업

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,6 +8,7 @@
   </head>
   <body>
     <div id="root"></div>
+    <div id="modal-root"></div>
     <script type="module" src="/src/main.tsx"></script>
   </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -11,8 +11,10 @@
   },
   "dependencies": {
     "@react-google-maps/api": "^2.20.7",
+    "axios": "^1.11.0",
     "react": "^19.1.1",
-    "react-dom": "^19.1.1"
+    "react-dom": "^19.1.1",
+    "zustand": "^5.0.8"
   },
   "devDependencies": {
     "@eslint/js": "^9.33.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,12 +11,18 @@ importers:
       '@react-google-maps/api':
         specifier: ^2.20.7
         version: 2.20.7(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      axios:
+        specifier: ^1.11.0
+        version: 1.11.0
       react:
         specifier: ^19.1.1
         version: 19.1.1
       react-dom:
         specifier: ^19.1.1
         version: 19.1.1(react@19.1.1)
+      zustand:
+        specifier: ^5.0.8
+        version: 5.0.8(@types/react@19.1.12)(react@19.1.1)
     devDependencies:
       '@eslint/js':
         specifier: ^9.33.0
@@ -669,9 +675,15 @@ packages:
     resolution: {integrity: sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA==}
     engines: {node: '>= 0.4'}
 
+  asynckit@0.4.0:
+    resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
+
   available-typed-arrays@1.0.7:
     resolution: {integrity: sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==}
     engines: {node: '>= 0.4'}
+
+  axios@1.11.0:
+    resolution: {integrity: sha512-1Lx3WLFQWm3ooKDYZD1eXmoGO9fxYQjrycfHFC8P0sCfQVXyROp0p9PFWBehewBOdCwHc+f/b8I0fMto5eSfwA==}
 
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
@@ -721,6 +733,10 @@ packages:
   color-name@1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
 
+  combined-stream@1.0.8:
+    resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
+    engines: {node: '>= 0.8'}
+
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
 
@@ -765,6 +781,10 @@ packages:
   define-properties@1.2.1:
     resolution: {integrity: sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==}
     engines: {node: '>= 0.4'}
+
+  delayed-stream@1.0.0:
+    resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
+    engines: {node: '>=0.4.0'}
 
   doctrine@2.1.0:
     resolution: {integrity: sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==}
@@ -948,9 +968,22 @@ packages:
   flatted@3.3.3:
     resolution: {integrity: sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==}
 
+  follow-redirects@1.15.11:
+    resolution: {integrity: sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==}
+    engines: {node: '>=4.0'}
+    peerDependencies:
+      debug: '*'
+    peerDependenciesMeta:
+      debug:
+        optional: true
+
   for-each@0.3.5:
     resolution: {integrity: sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==}
     engines: {node: '>= 0.4'}
+
+  form-data@4.0.4:
+    resolution: {integrity: sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==}
+    engines: {node: '>= 6'}
 
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
@@ -1236,6 +1269,14 @@ packages:
     resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
     engines: {node: '>=8.6'}
 
+  mime-db@1.52.0:
+    resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
+    engines: {node: '>= 0.6'}
+
+  mime-types@2.1.35:
+    resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
+    engines: {node: '>= 0.6'}
+
   minimatch@3.1.2:
     resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
 
@@ -1350,6 +1391,9 @@ packages:
 
   prop-types@15.8.1:
     resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
+
+  proxy-from-env@1.1.0:
+    resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
 
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
@@ -1638,6 +1682,24 @@ packages:
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
+
+  zustand@5.0.8:
+    resolution: {integrity: sha512-gyPKpIaxY9XcO2vSMrLbiER7QMAMGOQZVRdJ6Zi782jkbzZygq5GI9nG8g+sMgitRtndwaBSl7uiqC49o1SSiw==}
+    engines: {node: '>=12.20.0'}
+    peerDependencies:
+      '@types/react': '>=18.0.0'
+      immer: '>=9.0.6'
+      react: '>=18.0.0'
+      use-sync-external-store: '>=1.2.0'
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      immer:
+        optional: true
+      react:
+        optional: true
+      use-sync-external-store:
+        optional: true
 
 snapshots:
 
@@ -2224,9 +2286,19 @@ snapshots:
 
   async-function@1.0.0: {}
 
+  asynckit@0.4.0: {}
+
   available-typed-arrays@1.0.7:
     dependencies:
       possible-typed-array-names: 1.1.0
+
+  axios@1.11.0:
+    dependencies:
+      follow-redirects: 1.15.11
+      form-data: 4.0.4
+      proxy-from-env: 1.1.0
+    transitivePeerDependencies:
+      - debug
 
   balanced-match@1.0.2: {}
 
@@ -2282,6 +2354,10 @@ snapshots:
 
   color-name@1.1.4: {}
 
+  combined-stream@1.0.8:
+    dependencies:
+      delayed-stream: 1.0.0
+
   concat-map@0.0.1: {}
 
   convert-source-map@2.0.0: {}
@@ -2329,6 +2405,8 @@ snapshots:
       define-data-property: 1.1.4
       has-property-descriptors: 1.0.2
       object-keys: 1.1.1
+
+  delayed-stream@1.0.0: {}
 
   doctrine@2.1.0:
     dependencies:
@@ -2630,9 +2708,19 @@ snapshots:
 
   flatted@3.3.3: {}
 
+  follow-redirects@1.15.11: {}
+
   for-each@0.3.5:
     dependencies:
       is-callable: 1.2.7
+
+  form-data@4.0.4:
+    dependencies:
+      asynckit: 0.4.0
+      combined-stream: 1.0.8
+      es-set-tostringtag: 2.1.0
+      hasown: 2.0.2
+      mime-types: 2.1.35
 
   fsevents@2.3.3:
     optional: true
@@ -2917,6 +3005,12 @@ snapshots:
       braces: 3.0.3
       picomatch: 2.3.1
 
+  mime-db@1.52.0: {}
+
+  mime-types@2.1.35:
+    dependencies:
+      mime-db: 1.52.0
+
   minimatch@3.1.2:
     dependencies:
       brace-expansion: 1.1.12
@@ -3029,6 +3123,8 @@ snapshots:
       loose-envify: 1.4.0
       object-assign: 4.1.1
       react-is: 16.13.1
+
+  proxy-from-env@1.1.0: {}
 
   punycode@2.3.1: {}
 
@@ -3395,3 +3491,8 @@ snapshots:
   yallist@3.1.1: {}
 
   yocto-queue@0.1.0: {}
+
+  zustand@5.0.8(@types/react@19.1.12)(react@19.1.1):
+    optionalDependencies:
+      '@types/react': 19.1.12
+      react: 19.1.1

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,12 +1,14 @@
 import styles from "./App.module.css";
 import { Map } from "@/features/map";
 import { Modal } from "@/common/components/Modal";
+import { BottomSheet } from "@/common/components/BottomSheet";
 
 function App() {
   return (
     <div className={styles.mobileFullscreen}>
       <Map />
       <Modal />
+      <BottomSheet />
     </div>
   );
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,10 +1,12 @@
 import styles from "./App.module.css";
 import { Map } from "@/features/map";
+import { Modal } from "@/common/components/Modal";
 
 function App() {
   return (
     <div className={styles.mobileFullscreen}>
       <Map />
+      <Modal />
     </div>
   );
 }

--- a/src/common/components/BottomSheet.tsx
+++ b/src/common/components/BottomSheet.tsx
@@ -1,0 +1,42 @@
+import { createPortal } from "react-dom";
+import { useBottomSheetStore } from "@/common/hooks/useBottomSheetStore";
+import { useEffect } from "react";
+import styles from "./bottom-sheet.module.css";
+
+export function BottomSheet() {
+  const { isOpen, content, close, options } = useBottomSheetStore();
+
+  useEffect(() => {
+    if (!isOpen) return;
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") close();
+    };
+    document.addEventListener("keydown", onKeyDown);
+    return () => document.removeEventListener("keydown", onKeyDown);
+  }, [isOpen, close]);
+
+  if (!isOpen) return null;
+
+  const handleBackdropClick = () => {
+    if (options?.onBackdropClick) options.onBackdropClick();
+    else close();
+  };
+
+  const root = document.getElementById("modal-root") ?? document.body;
+
+  return createPortal(
+    <div className={styles.backdrop} onClick={handleBackdropClick}>
+      <div
+        className={styles.sheetWrapper}
+        onClick={e => e.stopPropagation()}
+        aria-label={options?.ariaLabel}
+        role="dialog"
+        aria-modal="true"
+      >
+        <div className={styles.handle} />
+        <div className={styles.content}>{content}</div>
+      </div>
+    </div>,
+    root
+  );
+}

--- a/src/common/components/BottomSheet.tsx
+++ b/src/common/components/BottomSheet.tsx
@@ -1,10 +1,15 @@
 import { createPortal } from "react-dom";
 import { useBottomSheetStore } from "@/common/hooks/useBottomSheetStore";
 import { useEffect } from "react";
-import styles from "./bottom-sheet.module.css";
+import { useBottomSheetInteraction } from "@/common/hooks/useBottomSheetInteraction";
+import { BottomSheetView } from "@/common/components/BottomSheetView";
+
+const PEEK_HEIGHT = 56;
 
 export function BottomSheet() {
   const { isOpen, content, close, options } = useBottomSheetStore();
+
+  const interaction = useBottomSheetInteraction(PEEK_HEIGHT);
 
   useEffect(() => {
     if (!isOpen) return;
@@ -17,26 +22,26 @@ export function BottomSheet() {
 
   if (!isOpen) return null;
 
-  const handleBackdropClick = () => {
-    if (options?.onBackdropClick) options.onBackdropClick();
-    else close();
-  };
-
   const root = document.getElementById("modal-root") ?? document.body;
 
   return createPortal(
-    <div className={styles.backdrop} onClick={handleBackdropClick}>
-      <div
-        className={styles.sheetWrapper}
-        onClick={e => e.stopPropagation()}
-        aria-label={options?.ariaLabel}
-        role="dialog"
-        aria-modal="true"
-      >
-        <div className={styles.handle} />
-        <div className={styles.content}>{content}</div>
-      </div>
-    </div>,
+    <BottomSheetView
+      translateY={interaction.translateY}
+      isDragging={interaction.isDragging}
+      measured={interaction.measured}
+      sheetRef={interaction.sheetRef}
+      handleRef={interaction.handleRef}
+      onPointerDown={interaction.onPointerDown}
+      onPointerMove={interaction.onPointerMove}
+      onPointerUp={interaction.onPointerUp}
+      onTouchStart={interaction.onTouchStart}
+      onTouchMove={interaction.onTouchMove}
+      onTouchEnd={interaction.onTouchEnd}
+      onBackdropClick={() => (options?.onBackdropClick ? options.onBackdropClick() : close())}
+      ariaLabel={options?.ariaLabel}
+    >
+      {content}
+    </BottomSheetView>,
     root
   );
 }

--- a/src/common/components/BottomSheetView.tsx
+++ b/src/common/components/BottomSheetView.tsx
@@ -1,0 +1,66 @@
+import styles from "./bottom-sheet.module.css";
+
+export type BottomSheetViewProps = {
+  translateY: number;
+  isDragging: boolean;
+  measured: boolean;
+  sheetRef: React.RefObject<HTMLDivElement>;
+  handleRef: React.RefObject<HTMLDivElement>;
+  onPointerDown: (e: React.PointerEvent) => void;
+  onPointerMove: (e: React.PointerEvent) => void;
+  onPointerUp: () => void;
+  onTouchStart: (e: React.TouchEvent) => void;
+  onTouchMove: (e: React.TouchEvent) => void;
+  onTouchEnd: () => void;
+  onBackdropClick: () => void;
+  ariaLabel?: string;
+  children?: React.ReactNode;
+};
+
+export function BottomSheetView(props: BottomSheetViewProps) {
+  const {
+    translateY,
+    isDragging,
+    measured,
+    sheetRef,
+    handleRef,
+    onPointerDown,
+    onPointerMove,
+    onPointerUp,
+    onTouchStart,
+    onTouchMove,
+    onTouchEnd,
+    onBackdropClick,
+    ariaLabel,
+    children
+  } = props;
+
+  return (
+    <div className={styles.backdrop} onClick={onBackdropClick}>
+      <div
+        ref={sheetRef}
+        className={`${styles.sheetWrapper} ${isDragging ? styles.dragging : ""} ${!measured ? styles.noTransition : ""}`}
+        style={{ transform: `translateY(${translateY}px)` }}
+        onClick={e => e.stopPropagation()}
+        aria-label={ariaLabel}
+        role="dialog"
+        aria-modal="true"
+      >
+        <div
+          ref={handleRef}
+          className={styles.handle}
+          onPointerDown={onPointerDown}
+          onPointerMove={onPointerMove}
+          onPointerUp={onPointerUp}
+          onPointerCancel={onPointerUp}
+          onTouchStart={onTouchStart}
+          onTouchMove={onTouchMove}
+          onTouchEnd={onTouchEnd}
+          onTouchCancel={onTouchEnd}
+        />
+        <div className={styles.peekSpacer} />
+        <div className={styles.content}>{children}</div>
+      </div>
+    </div>
+  );
+}

--- a/src/common/components/Modal.tsx
+++ b/src/common/components/Modal.tsx
@@ -1,0 +1,44 @@
+import { createPortal } from "react-dom";
+import { useModalStore } from "@/common/hooks/useModalStore";
+import { useEffect, useRef } from "react";
+import styles from "./modal.module.css";
+
+export function Modal() {
+  const { isOpen, content, close, options } = useModalStore();
+  const backdropRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!isOpen) return;
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") close();
+    };
+    document.addEventListener("keydown", onKeyDown);
+    return () => document.removeEventListener("keydown", onKeyDown);
+  }, [isOpen, close]);
+
+  if (!isOpen) return null;
+
+  const handleBackdropClick = () => {
+    if (options?.onBackdropClick) options.onBackdropClick();
+    else close();
+  };
+
+  const root = document.getElementById("modal-root") ?? document.body;
+
+  return createPortal(
+    <div ref={backdropRef} className={styles.backdrop} onClick={handleBackdropClick}>
+      <div className={styles.wrapper}>
+        <div
+          role="dialog"
+          aria-modal="true"
+          aria-label={options?.ariaLabel}
+          className={styles.modal}
+          onClick={e => e.stopPropagation()}
+        >
+          {content}
+        </div>
+      </div>
+    </div>,
+    root
+  );
+}

--- a/src/common/components/bottom-sheet.module.css
+++ b/src/common/components/bottom-sheet.module.css
@@ -1,54 +1,66 @@
 .backdrop {
   position: fixed;
   inset: 0;
-  background: rgba(0, 0, 0, 0.25);
+  background: transparent;
   z-index: 9998;
   display: flex;
   align-items: flex-end;
   justify-content: center;
+  pointer-events: none;
 }
 
 .sheetWrapper {
   width: 100%;
   max-width: 100%;
-  height: auto;
-  max-height: 70vh;
+  height: 70vh;
   background: #ffffff;
   border-top-left-radius: 16px;
   border-top-right-radius: 16px;
-  box-shadow: 0 -8px 24px rgba(0, 0, 0, 0.2);
+  box-shadow: 0 -8px 24px rgba(0, 0, 0, 0.118);
   padding: 8px 16px 16px 16px;
-  transform: translateY(0);
-  animation: slideUp 180ms ease-out;
+  will-change: transform;
+  transition: transform 180ms ease-out;
+  pointer-events: auto;
+}
+
+.dragging {
+  transition: none;
+}
+
+.noTransition {
+  transition: none;
 }
 
 .handle {
+  width: 100%;
+  height: 24px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: grab;
+  touch-action: none;
+}
+
+.handle::before {
+  content: "";
+  display: block;
   width: 64px;
   height: 6px;
   background: #e5e7eb;
   border-radius: 999px;
-  margin: 8px auto 12px auto;
+}
+
+.peekSpacer {
+  height: 24px;
 }
 
 .content {
   overflow: auto;
-  max-height: calc(70vh - 32px);
-  /* hide scrollbar cross-browser */
-  -ms-overflow-style: none; /* IE and Edge */
-  scrollbar-width: none; /* Firefox */
+  max-height: calc(70vh - 48px); /* 24(handle) + 24(spacer) */
+  -ms-overflow-style: none;
+  scrollbar-width: none;
 }
 
 .content::-webkit-scrollbar {
-  display: none; /* Chrome, Safari, Opera */
-}
-
-@keyframes slideUp {
-  from {
-    transform: translateY(24px);
-    opacity: 0.6;
-  }
-  to {
-    transform: translateY(0);
-    opacity: 1;
-  }
+  display: none;
 }

--- a/src/common/components/bottom-sheet.module.css
+++ b/src/common/components/bottom-sheet.module.css
@@ -1,0 +1,54 @@
+.backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.25);
+  z-index: 9998;
+  display: flex;
+  align-items: flex-end;
+  justify-content: center;
+}
+
+.sheetWrapper {
+  width: 100%;
+  max-width: 100%;
+  height: auto;
+  max-height: 70vh;
+  background: #ffffff;
+  border-top-left-radius: 16px;
+  border-top-right-radius: 16px;
+  box-shadow: 0 -8px 24px rgba(0, 0, 0, 0.2);
+  padding: 8px 16px 16px 16px;
+  transform: translateY(0);
+  animation: slideUp 180ms ease-out;
+}
+
+.handle {
+  width: 64px;
+  height: 6px;
+  background: #e5e7eb;
+  border-radius: 999px;
+  margin: 8px auto 12px auto;
+}
+
+.content {
+  overflow: auto;
+  max-height: calc(70vh - 32px);
+  /* hide scrollbar cross-browser */
+  -ms-overflow-style: none; /* IE and Edge */
+  scrollbar-width: none; /* Firefox */
+}
+
+.content::-webkit-scrollbar {
+  display: none; /* Chrome, Safari, Opera */
+}
+
+@keyframes slideUp {
+  from {
+    transform: translateY(24px);
+    opacity: 0.6;
+  }
+  to {
+    transform: translateY(0);
+    opacity: 1;
+  }
+}

--- a/src/common/components/modal.module.css
+++ b/src/common/components/modal.module.css
@@ -1,0 +1,32 @@
+.backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.45);
+  z-index: 9999;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  pointer-events: auto;
+}
+
+.wrapper {
+  width: 100%;
+  height: 100%;
+  padding: 24px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.modal {
+  width: clamp(220px, 70vw, 720px);
+  max-height: 70vh;
+  display: flex;
+  flex-direction: column;
+  background: rgb(255, 255, 255);
+  color: #000000;
+  border: 1px solid #e5e7eb;
+  border-radius: 16px;
+  padding: 20px 20px 16px 20px;
+  box-shadow: 0 24px 64px rgba(0, 0, 0, 0.25);
+}

--- a/src/common/hooks/useBottomSheetInteraction.ts
+++ b/src/common/hooks/useBottomSheetInteraction.ts
@@ -1,0 +1,107 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+
+export type BottomSheetInteraction = {
+  sheetRef: React.RefObject<HTMLDivElement>;
+  handleRef: React.RefObject<HTMLDivElement>;
+  translateY: number;
+  isDragging: boolean;
+  measured: boolean;
+  onPointerDown: (e: React.PointerEvent) => void;
+  onPointerMove: (e: React.PointerEvent) => void;
+  onPointerUp: () => void;
+  onTouchStart: (e: React.TouchEvent) => void;
+  onTouchMove: (e: React.TouchEvent) => void;
+  onTouchEnd: () => void;
+};
+
+export function useBottomSheetInteraction(peekHeight: number) {
+  const sheetRef = useRef<HTMLDivElement>(null);
+  const handleRef = useRef<HTMLDivElement>(null);
+  const startYRef = useRef(0);
+  const startTranslateRef = useRef(0);
+  const maxTranslateRef = useRef(0);
+
+  const initialTranslate = Math.max(Math.round(window.innerHeight * 0.7) - peekHeight, 0);
+  const [translateY, setTranslateY] = useState(initialTranslate);
+  const [isDragging, setIsDragging] = useState(false);
+  const [measured, setMeasured] = useState(false);
+
+  const recalc = useCallback(() => {
+    const el = sheetRef.current;
+    if (!el) return;
+    const h = el.getBoundingClientRect().height;
+    const maxTranslate = Math.max(h - peekHeight, 0);
+    maxTranslateRef.current = maxTranslate;
+    setTranslateY(maxTranslate);
+    setMeasured(true);
+  }, [peekHeight]);
+
+  useEffect(() => {
+    recalc();
+    const onResize = () => recalc();
+    window.addEventListener("resize", onResize);
+    return () => window.removeEventListener("resize", onResize);
+  }, [recalc]);
+
+  const onPointerDown = (e: React.PointerEvent) => {
+    if (e.button !== 0) return;
+    e.preventDefault();
+    setIsDragging(true);
+    startYRef.current = e.clientY;
+    startTranslateRef.current = translateY;
+    (e.currentTarget as HTMLElement).setPointerCapture(e.pointerId);
+  };
+
+  const onPointerMove = (e: React.PointerEvent) => {
+    if (!isDragging) return;
+    const dy = e.clientY - startYRef.current;
+    const next = Math.min(Math.max(startTranslateRef.current + dy, 0), maxTranslateRef.current);
+    setTranslateY(next);
+  };
+
+  const onPointerUp = () => {
+    if (!isDragging) return;
+    setIsDragging(false);
+    const over = maxTranslateRef.current;
+    const snapTo = translateY < over / 2 ? 0 : over;
+    setTranslateY(snapTo);
+  };
+
+  const onTouchStart = (e: React.TouchEvent) => {
+    if (e.touches.length === 0) return;
+    setIsDragging(true);
+    const touch = e.touches[0];
+    startYRef.current = touch.clientY;
+    startTranslateRef.current = translateY;
+  };
+
+  const onTouchMove = (e: React.TouchEvent) => {
+    if (!isDragging || e.touches.length === 0) return;
+    const touch = e.touches[0];
+    const dy = touch.clientY - startYRef.current;
+    const next = Math.min(Math.max(startTranslateRef.current + dy, 0), maxTranslateRef.current);
+    setTranslateY(next);
+  };
+
+  const onTouchEnd = () => {
+    if (!isDragging) return;
+    setIsDragging(false);
+    const over = maxTranslateRef.current;
+    const snapTo = translateY < over / 2 ? 0 : over;
+    setTranslateY(snapTo);
+  };
+
+  return {
+    sheetRef,
+    handleRef,
+    translateY,
+    isDragging,
+    measured,
+    onPointerDown,
+    onPointerMove,
+    onPointerUp,
+    onTouchStart,
+    onTouchMove,
+    onTouchEnd
+  } as BottomSheetInteraction;
+} 

--- a/src/common/hooks/useBottomSheetStore.ts
+++ b/src/common/hooks/useBottomSheetStore.ts
@@ -1,0 +1,23 @@
+import { ReactNode } from "react";
+import { create } from "zustand";
+
+export type BottomSheetOptions = {
+  onBackdropClick?: () => void;
+  ariaLabel?: string;
+};
+
+interface BottomSheetStore {
+  isOpen: boolean;
+  content: ReactNode | null;
+  options: BottomSheetOptions | null;
+  open: (content: ReactNode, options?: BottomSheetOptions) => void;
+  close: () => void;
+}
+
+export const useBottomSheetStore = create<BottomSheetStore>(set => ({
+  isOpen: false,
+  content: null,
+  options: null,
+  open: (content, options) => set({ isOpen: true, content, options: options ?? null }),
+  close: () => set({ isOpen: false, content: null, options: null })
+}));

--- a/src/common/hooks/useModalStore.ts
+++ b/src/common/hooks/useModalStore.ts
@@ -1,0 +1,23 @@
+import { create } from "zustand";
+import type { ReactNode } from "react";
+
+export type ModalOptions = {
+  onBackdropClick?: () => void;
+  ariaLabel?: string;
+};
+
+interface ModalStore {
+  isOpen: boolean;
+  content: ReactNode | null;
+  options: ModalOptions | null;
+  open: (content: ReactNode, options?: ModalOptions) => void;
+  close: () => void;
+}
+
+export const useModalStore = create<ModalStore>(set => ({
+  isOpen: false,
+  content: null,
+  options: null,
+  open: (content, options) => set({ isOpen: true, content, options: options ?? null }),
+  close: () => set({ isOpen: false, content: null, options: null })
+}));

--- a/src/common/utils/http.ts
+++ b/src/common/utils/http.ts
@@ -1,0 +1,22 @@
+import { isAxiosError } from "axios";
+
+export function extractAxiosErrorMessage(err: unknown) {
+  if (isAxiosError(err)) {
+    const status = err.response?.status;
+    const data = err.response?.data as unknown;
+    let serverMsg: string | undefined;
+    if (typeof data === "object" && data !== null && "message" in data) {
+      const maybe = (data as { message?: unknown }).message;
+      if (typeof maybe === "string") serverMsg = maybe;
+    }
+    const msg = serverMsg || err.message || "요청에 실패했습니다";
+    return status ? `API ${status}: ${msg}` : msg;
+  }
+
+  if (err && typeof err === "object" && "message" in err) {
+    const maybe = (err as { message?: unknown }).message;
+    return typeof maybe === "string" ? maybe : "알 수 없는 오류";
+  }
+
+  return String(err);
+}

--- a/src/common/utils/url.ts
+++ b/src/common/utils/url.ts
@@ -1,0 +1,6 @@
+export function buildApiUrl(baseUrl: string | undefined, path: string) {
+  const cleanedPath = path.startsWith("/") ? path : `/${path}`;
+  if (!baseUrl) return cleanedPath;
+  const trimmed = baseUrl.replace(/\/$/, "");
+  return `${trimmed}${cleanedPath}`;
+}

--- a/src/features/map/components/Map.tsx
+++ b/src/features/map/components/Map.tsx
@@ -1,7 +1,7 @@
 import { GoogleMap, Circle, useLoadScript } from "@react-google-maps/api";
 import { useCurrentPosition } from "../hooks/useCurrentPosition";
 import { useTodayWeather } from "../hooks/useTodayWeather";
-import { WeatherOverlay } from "./WeatherOverlay";
+import { WeatherOverlay } from ".";
 
 const DEFAULT_CENTER = { lat: 37.5665, lng: 126.978 }; // 서울 시청
 

--- a/src/features/map/components/Map.tsx
+++ b/src/features/map/components/Map.tsx
@@ -4,8 +4,7 @@ import { useTodayWeather } from "../hooks/useTodayWeather";
 import { WeatherOverlay } from ".";
 import { useEffect, useRef } from "react";
 import { useBottomSheetStore } from "@/common/hooks/useBottomSheetStore";
-import { ShelterBottomSheetContent } from "@/features/shelter";
-import type { ShelterItem } from "@/features/shelter";
+import { ShelterBottomSheet } from "@/features/shelter";
 
 const DEFAULT_CENTER = { lat: 37.5665, lng: 126.978 }; // 서울 시청
 
@@ -16,45 +15,14 @@ export default function Map() {
   const { position, accuracy } = useCurrentPosition();
   const { data: weather, loading, error } = useTodayWeather(position);
 
-  const openedRef = useRef(false);
   const { open } = useBottomSheetStore();
+  const openedRef = useRef(false);
 
   useEffect(() => {
-    if (!openedRef.current && isLoaded) {
-      const mockItems: ShelterItem[] = [
-        {
-          id: "1",
-          name: "000 대피소",
-          address: "000 대피소 도로명 주소 도로명 주소 도로명 주소 도로명",
-          distanceMeter: 200,
-          phone: "02-2019-2163"
-        },
-        {
-          id: "2",
-          name: "000 대피소",
-          address: "000 대피소 도로명 주소 도로명 주소 도로명 주소 도로명",
-          distanceMeter: 200,
-          phone: "02-2019-2163"
-        },
-        {
-          id: "3",
-          name: "000 대피소",
-          address: "000 대피소 도로명 주소 도로명 주소 도로명 주소 도로명",
-          distanceMeter: 200,
-          phone: "02-2019-2163"
-        },
-        {
-          id: "4",
-          name: "000 대피소",
-          address: "000 대피소 도로명 주소 도로명 주소 도로명 주소 도로명",
-          distanceMeter: 200,
-          phone: "02-2019-2163"
-        }
-      ];
-      open(<ShelterBottomSheetContent items={mockItems} />, { ariaLabel: "대피소 목록" });
-      openedRef.current = true;
-    }
-  }, [isLoaded, open]);
+    if (!isLoaded || !position || openedRef.current) return;
+    open(<ShelterBottomSheet position={position} />, { ariaLabel: "대피소 목록" });
+    openedRef.current = true;
+  }, [isLoaded, position, open]);
 
   if (!apiKey || !isLoaded) return null;
 

--- a/src/features/map/components/Map.tsx
+++ b/src/features/map/components/Map.tsx
@@ -1,5 +1,7 @@
 import { GoogleMap, Circle, useLoadScript } from "@react-google-maps/api";
 import { useCurrentPosition } from "../hooks/useCurrentPosition";
+import { useTodayWeather } from "../hooks/useTodayWeather";
+import { WeatherOverlay } from "./WeatherOverlay";
 
 const DEFAULT_CENTER = { lat: 37.5665, lng: 126.978 }; // 서울 시청
 
@@ -8,6 +10,7 @@ export default function Map() {
   const { isLoaded } = useLoadScript({ googleMapsApiKey: apiKey ?? "" });
 
   const { position, accuracy } = useCurrentPosition();
+  const { data: weather, loading, error } = useTodayWeather(position);
 
   if (!apiKey || !isLoaded) return null;
 
@@ -18,6 +21,8 @@ export default function Map() {
       zoom={position ? 15 : 12}
       options={{ fullscreenControl: false, streetViewControl: false, mapTypeControl: false }}
     >
+      {position && <WeatherOverlay weather={weather} loading={loading} error={error} />}
+
       {position && accuracy != null && (
         <Circle
           center={position}

--- a/src/features/map/components/Map.tsx
+++ b/src/features/map/components/Map.tsx
@@ -4,7 +4,8 @@ import { useTodayWeather } from "../hooks/useTodayWeather";
 import { WeatherOverlay } from ".";
 import { useEffect, useRef } from "react";
 import { useBottomSheetStore } from "@/common/hooks/useBottomSheetStore";
-import { ShelterBottomSheet } from "@/features/shelter";
+import { ShelterBottomSheetContent } from "@/features/shelter";
+import { useNearbyShelters } from "@/features/shelter";
 
 const DEFAULT_CENTER = { lat: 37.5665, lng: 126.978 }; // 서울 시청
 
@@ -15,14 +16,34 @@ export default function Map() {
   const { position, accuracy } = useCurrentPosition();
   const { data: weather, loading, error } = useTodayWeather(position);
 
+  const { data: shelters, error: sheltersError } = useNearbyShelters(position);
+
   const { open } = useBottomSheetStore();
-  const openedRef = useRef(false);
+  const openedOnceRef = useRef(false);
 
   useEffect(() => {
-    if (!isLoaded || !position || openedRef.current) return;
-    open(<ShelterBottomSheet position={position} />, { ariaLabel: "대피소 목록" });
-    openedRef.current = true;
-  }, [isLoaded, position, open]);
+    if (!isLoaded || !position) return;
+
+    if (sheltersError) {
+      open(<ShelterBottomSheetContent error={sheltersError} />, { ariaLabel: "대피소 목록" });
+      openedOnceRef.current = true;
+      return;
+    }
+
+    if (Array.isArray(shelters)) {
+      const items = shelters.map((s, idx) => ({
+        id: String(s.REARE_FCLT_NO || idx),
+        name: s.REARE_NM,
+        address: s.RONA_DADDR || s.DADDR,
+        distanceMeter: s.distance
+      }));
+      open(<ShelterBottomSheetContent items={items} />, { ariaLabel: "대피소 목록" });
+      openedOnceRef.current = true;
+    } else if (!openedOnceRef.current) {
+      open(<ShelterBottomSheetContent items={[]} />, { ariaLabel: "대피소 목록" });
+      openedOnceRef.current = true;
+    }
+  }, [isLoaded, position, shelters, sheltersError, open]);
 
   if (!apiKey || !isLoaded) return null;
 

--- a/src/features/map/components/Map.tsx
+++ b/src/features/map/components/Map.tsx
@@ -2,6 +2,10 @@ import { GoogleMap, Circle, useLoadScript } from "@react-google-maps/api";
 import { useCurrentPosition } from "../hooks/useCurrentPosition";
 import { useTodayWeather } from "../hooks/useTodayWeather";
 import { WeatherOverlay } from ".";
+import { useEffect, useRef } from "react";
+import { useBottomSheetStore } from "@/common/hooks/useBottomSheetStore";
+import { ShelterBottomSheetContent } from "@/features/shelter";
+import type { ShelterItem } from "@/features/shelter";
 
 const DEFAULT_CENTER = { lat: 37.5665, lng: 126.978 }; // 서울 시청
 
@@ -11,6 +15,46 @@ export default function Map() {
 
   const { position, accuracy } = useCurrentPosition();
   const { data: weather, loading, error } = useTodayWeather(position);
+
+  const openedRef = useRef(false);
+  const { open } = useBottomSheetStore();
+
+  useEffect(() => {
+    if (!openedRef.current && isLoaded) {
+      const mockItems: ShelterItem[] = [
+        {
+          id: "1",
+          name: "000 대피소",
+          address: "000 대피소 도로명 주소 도로명 주소 도로명 주소 도로명",
+          distanceMeter: 200,
+          phone: "02-2019-2163"
+        },
+        {
+          id: "2",
+          name: "000 대피소",
+          address: "000 대피소 도로명 주소 도로명 주소 도로명 주소 도로명",
+          distanceMeter: 200,
+          phone: "02-2019-2163"
+        },
+        {
+          id: "3",
+          name: "000 대피소",
+          address: "000 대피소 도로명 주소 도로명 주소 도로명 주소 도로명",
+          distanceMeter: 200,
+          phone: "02-2019-2163"
+        },
+        {
+          id: "4",
+          name: "000 대피소",
+          address: "000 대피소 도로명 주소 도로명 주소 도로명 주소 도로명",
+          distanceMeter: 200,
+          phone: "02-2019-2163"
+        }
+      ];
+      open(<ShelterBottomSheetContent items={mockItems} />, { ariaLabel: "대피소 목록" });
+      openedRef.current = true;
+    }
+  }, [isLoaded, open]);
 
   if (!apiKey || !isLoaded) return null;
 

--- a/src/features/map/components/WeatherButton.tsx
+++ b/src/features/map/components/WeatherButton.tsx
@@ -1,0 +1,21 @@
+import styles from "./WeatherOverlay.module.css";
+
+export type WeatherButtonProps = {
+  label: string;
+  disabled?: boolean;
+  onClick?: () => void;
+};
+
+export function WeatherButton({ label, disabled, onClick }: WeatherButtonProps) {
+  return (
+    <button
+      type="button"
+      className={styles.button}
+      disabled={disabled}
+      onClick={onClick}
+      aria-expanded={false}
+    >
+      {label}
+    </button>
+  );
+}

--- a/src/features/map/components/WeatherModalContent.tsx
+++ b/src/features/map/components/WeatherModalContent.tsx
@@ -1,0 +1,77 @@
+import type { TodayWeatherResponse } from "../schemas/weather.schema";
+import styles from "./WeatherOverlay.module.css";
+import { toEmojiByCode, normalizeTemp, toSkyKorean } from "../utils/weather";
+
+export function WeatherModalContent({
+  weather,
+  loading,
+  error
+}: {
+  weather: TodayWeatherResponse | null;
+  loading?: boolean;
+  error?: string | null;
+}) {
+  return (
+    <>
+      <div className={styles.header}>
+        <strong className={styles.title}>오늘의 날씨</strong>
+      </div>
+      <div className={styles.contentScroll}>
+        {loading && <div>불러오는 중...</div>}
+        {error && !loading && <div style={{ color: "#ef4444" }}>오류: {error}</div>}
+        {!loading && !error && weather && (
+          <>
+            <div className={styles.hero}>
+              <div className={styles.location}>{weather.locationName}</div>
+              <div className={styles.temp}>{normalizeTemp(weather.tmp)}</div>
+              <div className={styles.skyText}>{toSkyKorean(weather.sky, weather.pty)}</div>
+            </div>
+            <div className={styles.sectionTitle}>상세 정보</div>
+            <div className={styles.sectionCard}>
+              <div className={styles.row}>
+                <div className={styles.label}>강수확률</div>
+                <div className={styles.value}>{weather.pop}%</div>
+              </div>
+              <div className={styles.row}>
+                <div className={styles.label}>강수형태</div>
+                <div className={styles.value}>{weather.pty === "0" ? "없음" : weather.pty}</div>
+              </div>
+              <div className={styles.row}>
+                <div className={styles.label}>1시간 강수량</div>
+                <div className={styles.value}>{weather.pcp}</div>
+              </div>
+              <div className={styles.row}>
+                <div className={styles.label}>하늘상태</div>
+                <div className={styles.value}>{weather.sky}</div>
+              </div>
+              <div className={styles.row}>
+                <div className={styles.label}>1시간 기온</div>
+                <div className={styles.value}>{normalizeTemp(weather.tmp)}</div>
+              </div>
+              <div className={styles.row}>
+                <div className={styles.label}>풍속(동서성분)</div>
+                <div className={styles.value}>{weather.uuu}</div>
+              </div>
+              <div className={styles.row}>
+                <div className={styles.label}>풍속(남북성분)</div>
+                <div className={styles.value}>{weather.vvv}</div>
+              </div>
+              <div className={styles.row}>
+                <div className={styles.label}>파고</div>
+                <div className={styles.value}>{weather.wav}</div>
+              </div>
+              <div className={styles.row}>
+                <div className={styles.label}>풍향</div>
+                <div className={styles.value}>{weather.vec}</div>
+              </div>
+              <div className={styles.row}>
+                <div className={styles.label}>풍속</div>
+                <div className={styles.value}>{weather.wsd} m/s</div>
+              </div>
+            </div>
+          </>
+        )}
+      </div>
+    </>
+  );
+}

--- a/src/features/map/components/WeatherModalContent.tsx
+++ b/src/features/map/components/WeatherModalContent.tsx
@@ -1,6 +1,6 @@
 import type { TodayWeatherResponse } from "../schemas/weather.schema";
 import styles from "./WeatherOverlay.module.css";
-import { toEmojiByCode, normalizeTemp, toSkyKorean } from "../utils/weather";
+import { normalizeTemp, toSkyKorean } from "../utils/weather";
 
 export function WeatherModalContent({
   weather,
@@ -39,10 +39,6 @@ export function WeatherModalContent({
               <div className={styles.row}>
                 <div className={styles.label}>1시간 강수량</div>
                 <div className={styles.value}>{weather.pcp}</div>
-              </div>
-              <div className={styles.row}>
-                <div className={styles.label}>하늘상태</div>
-                <div className={styles.value}>{weather.sky}</div>
               </div>
               <div className={styles.row}>
                 <div className={styles.label}>1시간 기온</div>

--- a/src/features/map/components/WeatherOverlay.module.css
+++ b/src/features/map/components/WeatherOverlay.module.css
@@ -1,0 +1,164 @@
+.container {
+  position: absolute;
+  left: 12px;
+  top: 12px;
+  z-index: 2;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  pointer-events: auto;
+}
+
+.button {
+  background: rgba(17, 24, 39, 0.8);
+  color: #fff;
+  border: 1px solid #374151;
+  padding: 10px 14px;
+  border-radius: 999px;
+  font-size: 16px;
+  line-height: 1.1;
+  user-select: none;
+  -webkit-backdrop-filter: saturate(180%) blur(6px);
+  backdrop-filter: saturate(180%) blur(6px);
+  box-shadow: 0 6px 14px rgba(0, 0, 0, 0.25);
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.button:not(:disabled) {
+  cursor: pointer;
+}
+
+.button:disabled {
+  cursor: default;
+  opacity: 0.7;
+}
+
+.backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.45);
+  z-index: 9999;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  pointer-events: auto;
+}
+
+.wrapper {
+  width: 100%;
+  height: 100%;
+  padding: 24px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.modal {
+  width: clamp(320px, 70vw, 720px);
+  max-height: 88vh;
+  display: flex;
+  flex-direction: column;
+  background: rgba(255, 255, 255, 0.95);
+  color: #000000;
+  border: 1px solid #e5e7eb;
+  border-radius: 16px;
+  padding: 20px 20px 16px 20px;
+  box-shadow: 0 24px 64px rgba(0, 0, 0, 0.25);
+}
+
+.header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 12px;
+}
+
+.title {
+  font-size: clamp(18px, 2.4vw, 24px);
+  font-weight: 800;
+  letter-spacing: -0.02em;
+}
+
+.closeBtn {
+  background: transparent;
+  color: #6b7280;
+  border: 0;
+  cursor: pointer;
+  font-size: 22px;
+  line-height: 1;
+}
+
+.contentScroll {
+  flex: 1;
+  overflow: auto;
+  -ms-overflow-style: none; /* IE/Edge */
+  scrollbar-width: none; /* Firefox */
+}
+
+.contentScroll::-webkit-scrollbar {
+  display: none; /* Chrome/Safari */
+}
+
+.hero {
+  background: #f1f4f8;
+  border-radius: 20px;
+  padding: clamp(16px, 3vw, 24px) 16px;
+  text-align: center;
+  margin-bottom: 16px;
+}
+
+.location {
+  color: #65686f;
+  font-size: clamp(14px, 2vw, 18px);
+  font-weight: 600;
+  margin-bottom: 8px;
+}
+
+.temp {
+  font-size: clamp(40px, 10vw, 72px);
+  font-weight: 800;
+  color: #4880ee;
+  letter-spacing: -0.02em;
+}
+
+.skyText {
+  margin-top: 12px;
+  font-size: clamp(16px, 2.6vw, 24px);
+  font-weight: 700;
+}
+
+.sectionTitle {
+  font-size: clamp(16px, 2.4vw, 20px);
+  font-weight: 800;
+  margin: 8px 0 6px 0;
+}
+
+.sectionCard {
+  background: #ffffff;
+  border: 1px solid #e5e7eb;
+  border-radius: 12px;
+}
+
+.row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: clamp(12px, 2.2vw, 16px);
+}
+
+.row + .row {
+  border-top: 1px solid #e5e7eb;
+}
+
+.label {
+  color: #6b7280;
+  font-size: clamp(14px, 2vw, 16px);
+}
+
+.value {
+  color: #111827;
+  font-weight: 800;
+  font-size: clamp(15px, 2.2vw, 18px);
+}

--- a/src/features/map/components/WeatherOverlay.tsx
+++ b/src/features/map/components/WeatherOverlay.tsx
@@ -1,9 +1,10 @@
-import { memo, useMemo } from "react";
+import { memo } from "react";
 import type { TodayWeatherResponse } from "../schemas/weather.schema";
 import styles from "./WeatherOverlay.module.css";
-import { toEmojiByCode, normalizeTemp } from "../utils/weather";
 import { useModalStore } from "@/common/hooks/useModalStore";
 import { WeatherModalContent } from "./WeatherModalContent";
+import { useWeatherButtonLabel } from "../hooks/useWeatherButtonLabel";
+import { WeatherButton } from "./WeatherButton";
 
 type Props = {
   weather: TodayWeatherResponse | null;
@@ -14,14 +15,7 @@ type Props = {
 function WeatherOverlayComponent({ weather, loading, error }: Props) {
   const open = useModalStore(state => state.open);
 
-  const buttonText = useMemo(() => {
-    if (loading) return "불러오는 중...";
-    if (error) return "오류";
-    if (!weather) return "날씨 없음";
-    const emoji = toEmojiByCode(weather.sky, weather.pty);
-    const temp = normalizeTemp(weather.tmp);
-    return `${emoji} ${temp}`;
-  }, [weather, loading, error]);
+  const buttonText = useWeatherButtonLabel(weather, loading, error);
 
   const handleOpen = () => {
     open(<WeatherModalContent weather={weather} loading={loading} error={error} />, {
@@ -31,15 +25,7 @@ function WeatherOverlayComponent({ weather, loading, error }: Props) {
 
   return (
     <div className={styles.container}>
-      <button
-        type="button"
-        className={styles.button}
-        disabled={loading || !!error}
-        onClick={handleOpen}
-        aria-expanded={false}
-      >
-        {buttonText}
-      </button>
+      <WeatherButton label={buttonText} disabled={loading || !!error} onClick={handleOpen} />
     </div>
   );
 }

--- a/src/features/map/components/WeatherOverlay.tsx
+++ b/src/features/map/components/WeatherOverlay.tsx
@@ -1,0 +1,47 @@
+import { memo, useMemo } from "react";
+import type { TodayWeatherResponse } from "../schemas/weather.schema";
+import styles from "./WeatherOverlay.module.css";
+import { toEmojiByCode, normalizeTemp } from "../utils/weather";
+import { useModalStore } from "@/common/hooks/useModalStore";
+import { WeatherModalContent } from "./WeatherModalContent";
+
+type Props = {
+  weather: TodayWeatherResponse | null;
+  loading?: boolean;
+  error?: string | null;
+};
+
+function WeatherOverlayComponent({ weather, loading, error }: Props) {
+  const open = useModalStore(state => state.open);
+
+  const buttonText = useMemo(() => {
+    if (loading) return "불러오는 중...";
+    if (error) return "오류";
+    if (!weather) return "날씨 없음";
+    const emoji = toEmojiByCode(weather.sky, weather.pty);
+    const temp = normalizeTemp(weather.tmp);
+    return `${emoji} ${temp}`;
+  }, [weather, loading, error]);
+
+  const handleOpen = () => {
+    open(<WeatherModalContent weather={weather} loading={loading} error={error} />, {
+      ariaLabel: "오늘의 날씨"
+    });
+  };
+
+  return (
+    <div className={styles.container}>
+      <button
+        type="button"
+        className={styles.button}
+        disabled={loading || !!error}
+        onClick={handleOpen}
+        aria-expanded={false}
+      >
+        {buttonText}
+      </button>
+    </div>
+  );
+}
+
+export const WeatherOverlay = memo(WeatherOverlayComponent);

--- a/src/features/map/components/WeatherOverlay.tsx
+++ b/src/features/map/components/WeatherOverlay.tsx
@@ -2,9 +2,9 @@ import { memo } from "react";
 import type { TodayWeatherResponse } from "../schemas/weather.schema";
 import styles from "./WeatherOverlay.module.css";
 import { useModalStore } from "@/common/hooks/useModalStore";
-import { WeatherModalContent } from "./WeatherModalContent";
+import { WeatherModalContent } from ".";
+import { WeatherButton } from ".";
 import { useWeatherButtonLabel } from "../hooks/useWeatherButtonLabel";
-import { WeatherButton } from "./WeatherButton";
 
 type Props = {
   weather: TodayWeatherResponse | null;

--- a/src/features/map/components/index.ts
+++ b/src/features/map/components/index.ts
@@ -1,0 +1,2 @@
+export { WeatherOverlay } from "./WeatherOverlay";
+export { WeatherModalContent } from "./WeatherModalContent";

--- a/src/features/map/components/index.ts
+++ b/src/features/map/components/index.ts
@@ -1,3 +1,3 @@
+export { WeatherButton } from "./WeatherButton";
 export { WeatherOverlay } from "./WeatherOverlay";
 export { WeatherModalContent } from "./WeatherModalContent";
-export { WeatherButton } from "./WeatherButton";

--- a/src/features/map/components/index.ts
+++ b/src/features/map/components/index.ts
@@ -1,2 +1,3 @@
 export { WeatherOverlay } from "./WeatherOverlay";
 export { WeatherModalContent } from "./WeatherModalContent";
+export { WeatherButton } from "./WeatherButton";

--- a/src/features/map/hooks/useTodayWeather.ts
+++ b/src/features/map/hooks/useTodayWeather.ts
@@ -1,0 +1,46 @@
+import { useEffect, useState } from "react";
+import { fetchTodayWeather } from "../services/weather";
+import { toTodayWeatherResponse } from "../schemas/weather.schema";
+import type { TodayWeatherResponse } from "../schemas/weather.schema";
+import { extractAxiosErrorMessage } from "../../../common/utils/http";
+
+export function useTodayWeather(
+  position: google.maps.LatLngLiteral | null,
+  options?: { baseUrl?: string }
+) {
+  const [data, setData] = useState<TodayWeatherResponse | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!position) return;
+
+    let aborted = false;
+    const controller = new AbortController();
+
+    setLoading(true);
+    setError(null);
+
+    fetchTodayWeather({ userLat: position.lat, userLot: position.lng, baseUrl: options?.baseUrl })
+      .then(json => {
+        if (aborted) return;
+        const parsed = toTodayWeatherResponse(json);
+        setData(parsed);
+      })
+      .catch(err => {
+        if (aborted) return;
+        setError(extractAxiosErrorMessage(err));
+      })
+      .finally(() => {
+        if (aborted) return;
+        setLoading(false);
+      });
+
+    return () => {
+      aborted = true;
+      controller.abort();
+    };
+  }, [position?.lat, position?.lng, options?.baseUrl]);
+
+  return { data, loading, error } as const;
+}

--- a/src/features/map/hooks/useTodayWeather.ts
+++ b/src/features/map/hooks/useTodayWeather.ts
@@ -21,7 +21,12 @@ export function useTodayWeather(
     setLoading(true);
     setError(null);
 
-    fetchTodayWeather({ userLat: position.lat, userLot: position.lng, baseUrl: options?.baseUrl })
+    fetchTodayWeather({
+      userLat: position.lat,
+      userLot: position.lng,
+      baseUrl: options?.baseUrl,
+      signal: controller.signal
+    })
       .then(json => {
         if (aborted) return;
         const parsed = toTodayWeatherResponse(json);
@@ -40,7 +45,7 @@ export function useTodayWeather(
       aborted = true;
       controller.abort();
     };
-  }, [position?.lat, position?.lng, options?.baseUrl]);
+  }, [position, options?.baseUrl]);
 
   return { data, loading, error } as const;
 }

--- a/src/features/map/hooks/useWeatherButtonLabel.ts
+++ b/src/features/map/hooks/useWeatherButtonLabel.ts
@@ -1,0 +1,18 @@
+import { useMemo } from "react";
+import type { TodayWeatherResponse } from "../schemas/weather.schema";
+import { toEmojiByCode, normalizeTemp } from "../utils/weather";
+
+export function useWeatherButtonLabel(
+  weather: TodayWeatherResponse | null,
+  loading?: boolean,
+  error?: string | null
+) {
+  return useMemo(() => {
+    if (loading) return "불러오는 중...";
+    if (error) return "오류";
+    if (!weather) return "날씨 없음";
+    const emoji = toEmojiByCode(weather.sky, weather.pty);
+    const temp = normalizeTemp(weather.tmp);
+    return `${emoji} ${temp}`;
+  }, [weather, loading, error]);
+}

--- a/src/features/map/index.ts
+++ b/src/features/map/index.ts
@@ -1,1 +1,2 @@
 export { default as Map } from "./components/Map";
+export * from "./components";

--- a/src/features/map/schemas/weather.schema.ts
+++ b/src/features/map/schemas/weather.schema.ts
@@ -1,0 +1,51 @@
+export type TodayWeatherResponse = {
+  baseDate: string;
+  baseTime: string;
+  fcstTime: string;
+  locationName: string;
+  nx: number;
+  ny: number;
+  tmp: string;
+  uuu: string;
+  vvv: string;
+  vec: string;
+  wsd: string;
+  sky: string;
+  pty: string;
+  pop: string;
+  wav: string;
+  pcp: string;
+};
+
+export function isTodayWeatherResponse(input: unknown): input is TodayWeatherResponse {
+  if (typeof input !== "object" || input === null) return false;
+  const obj = input as Record<string, unknown>;
+  const requiredStringFields = [
+    "baseDate",
+    "baseTime",
+    "fcstTime",
+    "locationName",
+    "tmp",
+    "uuu",
+    "vvv",
+    "vec",
+    "wsd",
+    "sky",
+    "pty",
+    "pop",
+    "wav",
+    "pcp"
+  ];
+  for (const key of requiredStringFields) {
+    if (typeof obj[key] !== "string") return false;
+  }
+  if (typeof obj["nx"] !== "number" || typeof obj["ny"] !== "number") return false;
+  return true;
+}
+
+export function toTodayWeatherResponse(input: unknown): TodayWeatherResponse {
+  if (!isTodayWeatherResponse(input)) {
+    throw new Error("Invalid TodayWeatherResponse payload");
+  }
+  return input;
+}

--- a/src/features/map/services/weather.ts
+++ b/src/features/map/services/weather.ts
@@ -1,0 +1,25 @@
+import axios from "axios";
+import { buildApiUrl } from "../../../common/utils/url";
+
+export async function fetchTodayWeather(params: {
+  userLat: number;
+  userLot: number;
+  baseUrl?: string;
+}) {
+  const { userLat, userLot, baseUrl } = params;
+
+  const urlStr = buildApiUrl(baseUrl, "/weather/today");
+
+  const res = await axios.get(urlStr, {
+    headers: {
+      userLat: String(userLat),
+      userLot: String(userLot)
+    },
+    params: {
+      userLat,
+      userLot
+    }
+  });
+
+  return res.data;
+}

--- a/src/features/map/services/weather.ts
+++ b/src/features/map/services/weather.ts
@@ -5,8 +5,9 @@ export async function fetchTodayWeather(params: {
   userLat: number;
   userLot: number;
   baseUrl?: string;
+  signal?: AbortSignal;
 }) {
-  const { userLat, userLot, baseUrl } = params;
+  const { userLat, userLot, baseUrl, signal } = params;
 
   const urlStr = buildApiUrl(baseUrl, "/weather/today");
 
@@ -18,7 +19,8 @@ export async function fetchTodayWeather(params: {
     params: {
       userLat,
       userLot
-    }
+    },
+    signal
   });
 
   return res.data;

--- a/src/features/map/utils/weather.ts
+++ b/src/features/map/utils/weather.ts
@@ -1,0 +1,39 @@
+export function toEmojiByCode(sky: string, pty?: string) {
+  if (pty && pty !== "0") return "🌧️";
+  switch (sky) {
+    case "1":
+      return "☀️";
+    case "2":
+      return "🌤️";
+    case "3":
+      return "🌥️";
+    case "4":
+      return "☁️";
+    default:
+      return "☀️";
+  }
+}
+
+export function normalizeTemp(tmp: string | number | undefined) {
+  if (tmp == null) return "-";
+  const str = String(tmp).trim();
+  if (/°C$/.test(str)) return str;
+  if (!Number.isNaN(Number(str))) return `${str}°C`;
+  return str;
+}
+
+export function toSkyKorean(code: string, pty: string | undefined) {
+  if (pty && pty !== "0") return "강수";
+  switch (code) {
+    case "1":
+      return "맑음";
+    case "2":
+      return "구름조금";
+    case "3":
+      return "구름많음";
+    case "4":
+      return "흐림";
+    default:
+      return code;
+  }
+}

--- a/src/features/shelter/components/ShelterBottomSheet.tsx
+++ b/src/features/shelter/components/ShelterBottomSheet.tsx
@@ -2,9 +2,8 @@ import { useNearbyShelters } from "../hooks/useNearbyShelters";
 import { ShelterBottomSheetContent } from "./ShelterBottomSheetContent";
 
 export function ShelterBottomSheet({ position }: { position: google.maps.LatLngLiteral }) {
-  const { data: shelters, loading, error } = useNearbyShelters(position);
+  const { data: shelters, error } = useNearbyShelters(position);
 
-  if (loading) return <ShelterBottomSheetContent loading />;
   if (error) return <ShelterBottomSheetContent error={error} />;
 
   const items = Array.isArray(shelters)

--- a/src/features/shelter/components/ShelterBottomSheet.tsx
+++ b/src/features/shelter/components/ShelterBottomSheet.tsx
@@ -1,0 +1,20 @@
+import { useNearbyShelters } from "../hooks/useNearbyShelters";
+import { ShelterBottomSheetContent } from "./ShelterBottomSheetContent";
+
+export function ShelterBottomSheet({ position }: { position: google.maps.LatLngLiteral }) {
+  const { data: shelters, loading, error } = useNearbyShelters(position);
+
+  if (loading) return <ShelterBottomSheetContent loading />;
+  if (error) return <ShelterBottomSheetContent error={error} />;
+
+  const items = Array.isArray(shelters)
+    ? shelters.map((s, idx) => ({
+        id: String(s.REARE_FCLT_NO || idx),
+        name: s.REARE_NM,
+        address: s.RONA_DADDR || s.DADDR,
+        distanceMeter: s.distance
+      }))
+    : [];
+
+  return <ShelterBottomSheetContent items={items} />;
+}

--- a/src/features/shelter/components/ShelterBottomSheetContent.tsx
+++ b/src/features/shelter/components/ShelterBottomSheetContent.tsx
@@ -1,0 +1,27 @@
+import styles from "./shelter-bottom-sheet-content.module.css";
+
+export type ShelterItem = {
+  id: string;
+  name: string; // 대피소명
+  address: string; // 도로명 주소
+  distanceMeter: number; // 거리(m)
+  phone: string; // 연락처
+};
+
+export function ShelterBottomSheetContent({ items }: { items: ShelterItem[] }) {
+  return (
+    <div className={styles.list}>
+      {items.map(item => (
+        <div key={item.id} className={styles.card}>
+          <div className={styles.title}>{item.name}</div>
+          <div className={styles.address}>{item.address}</div>
+          <div className={styles.meta}>
+            <span className={styles.distance}>{item.distanceMeter}m</span>
+            <span className={styles.separator}>|</span>
+            <span className={styles.phone}>{item.phone}</span>
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/features/shelter/components/ShelterBottomSheetContent.tsx
+++ b/src/features/shelter/components/ShelterBottomSheetContent.tsx
@@ -5,23 +5,34 @@ export type ShelterItem = {
   name: string; // 대피소명
   address: string; // 도로명 주소
   distanceMeter: number; // 거리(m)
-  phone: string; // 연락처
 };
 
-export function ShelterBottomSheetContent({ items }: { items: ShelterItem[] }) {
+export function ShelterBottomSheetContent({
+  items,
+  loading,
+  error
+}: {
+  items?: ShelterItem[];
+  loading?: boolean;
+  error?: string | null;
+}) {
   return (
     <div className={styles.list}>
-      {items.map(item => (
-        <div key={item.id} className={styles.card}>
-          <div className={styles.title}>{item.name}</div>
-          <div className={styles.address}>{item.address}</div>
-          <div className={styles.meta}>
-            <span className={styles.distance}>{item.distanceMeter}m</span>
-            <span className={styles.separator}>|</span>
-            <span className={styles.phone}>{item.phone}</span>
+      {loading && <div>불러오는 중...</div>}
+      {error && !loading && <div style={{ color: "#ef4444" }}>오류: {error}</div>}
+      {!loading && !error && items && items.length === 0 && <div>주변 대피소가 없습니다.</div>}
+      {!loading &&
+        !error &&
+        items &&
+        items.map(item => (
+          <div key={item.id} className={styles.card}>
+            <div className={styles.title}>{item.name}</div>
+            <div className={styles.address}>{item.address}</div>
+            <div className={styles.meta}>
+              <span className={styles.distance}>{item.distanceMeter}m</span>
+            </div>
           </div>
-        </div>
-      ))}
+        ))}
     </div>
   );
 }

--- a/src/features/shelter/components/ShelterBottomSheetContent.tsx
+++ b/src/features/shelter/components/ShelterBottomSheetContent.tsx
@@ -9,21 +9,15 @@ export type ShelterItem = {
 
 export function ShelterBottomSheetContent({
   items,
-  loading,
   error
 }: {
   items?: ShelterItem[];
-  loading?: boolean;
   error?: string | null;
 }) {
   return (
     <div className={styles.list}>
-      {loading && <div>불러오는 중...</div>}
-      {error && !loading && <div style={{ color: "#ef4444" }}>오류: {error}</div>}
-      {!loading && !error && items && items.length === 0 && <div>주변 대피소가 없습니다.</div>}
-      {!loading &&
-        !error &&
-        items &&
+      {error && <div style={{ color: "#ef4444" }}>오류: {error}</div>}
+      {items &&
         items.map(item => (
           <div key={item.id} className={styles.card}>
             <div className={styles.title}>{item.name}</div>

--- a/src/features/shelter/components/shelter-bottom-sheet-content.module.css
+++ b/src/features/shelter/components/shelter-bottom-sheet-content.module.css
@@ -1,0 +1,42 @@
+.list {
+  display: flex;
+  flex-direction: column;
+}
+
+.card {
+  padding: 16px 8px;
+  border-bottom: 1px solid #eeeeee;
+}
+
+.title {
+  font-weight: 800;
+  font-size: 20px;
+  line-height: 1.2;
+  color: #006cff;
+}
+
+.address {
+  margin-top: 6px;
+  color: #aaaaaa;
+  font-size: 14px;
+}
+
+.meta {
+  margin-top: 10px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.distance {
+  color: #000000;
+  font-weight: 600;
+}
+
+.separator {
+  color: #999999;
+}
+
+.phone {
+  color: #000000;
+}

--- a/src/features/shelter/components/shelter-bottom-sheet-content.module.css
+++ b/src/features/shelter/components/shelter-bottom-sheet-content.module.css
@@ -32,11 +32,3 @@
   color: #000000;
   font-weight: 600;
 }
-
-.separator {
-  color: #999999;
-}
-
-.phone {
-  color: #000000;
-}

--- a/src/features/shelter/hooks/useNearbyShelters.ts
+++ b/src/features/shelter/hooks/useNearbyShelters.ts
@@ -1,0 +1,49 @@
+import { useEffect, useState } from "react";
+import { fetchNearbyShelters } from "../services/shelter";
+import type { NearbyShelterApiResponse } from "../schemas/shelter.schema";
+import { extractAxiosErrorMessage } from "@/common/utils/http";
+
+export function useNearbyShelters(
+  position: google.maps.LatLngLiteral | null,
+  options?: { baseUrl?: string }
+) {
+  const [data, setData] = useState<NearbyShelterApiResponse | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!position) return;
+
+    let aborted = false;
+    const controller = new AbortController();
+
+    setLoading(true);
+    setError(null);
+
+    fetchNearbyShelters({
+      userLat: position.lat,
+      userLot: position.lng,
+      baseUrl: options?.baseUrl,
+      signal: controller.signal
+    })
+      .then(res => {
+        if (aborted) return;
+        setData(res);
+      })
+      .catch(err => {
+        if (aborted) return;
+        setError(extractAxiosErrorMessage(err));
+      })
+      .finally(() => {
+        if (aborted) return;
+        setLoading(false);
+      });
+
+    return () => {
+      aborted = true;
+      controller.abort();
+    };
+  }, [position, options?.baseUrl]);
+
+  return { data, loading, error } as const;
+}

--- a/src/features/shelter/index.ts
+++ b/src/features/shelter/index.ts
@@ -1,2 +1,5 @@
 export { ShelterBottomSheetContent } from "./components/ShelterBottomSheetContent";
 export type { ShelterItem } from "./components/ShelterBottomSheetContent";
+export { useNearbyShelters } from "./hooks/useNearbyShelters";
+export type { NearbyShelterApiResponse, NearbyShelterApiItem } from "./schemas/shelter.schema";
+export { ShelterBottomSheet } from "./components/ShelterBottomSheet";

--- a/src/features/shelter/index.ts
+++ b/src/features/shelter/index.ts
@@ -1,0 +1,2 @@
+export { ShelterBottomSheetContent } from "./components/ShelterBottomSheetContent";
+export type { ShelterItem } from "./components/ShelterBottomSheetContent";

--- a/src/features/shelter/schemas/shelter.schema.ts
+++ b/src/features/shelter/schemas/shelter.schema.ts
@@ -1,0 +1,24 @@
+export type NearbyShelterApiItem = {
+  distance: number;
+  REARE_NM: string;
+  SNDY_OPER_BGNG_HR: string;
+  MDFCN_HR: string;
+  RONA_DADDR: string;
+  LHLDY_OPER_END_HR: string;
+  DADDR: string;
+  UTZTN_PSBLTY_TNOP: number;
+  WKDY_OPER_BGNG_HR: string;
+  STDY_OPER_END_HR: string;
+  SNDY_OPER_END_HR: string;
+  FCLT_TYPE: string;
+  FCLTY_SCLAS: string;
+  REARE_FCLT_NO: number;
+  LOT: number;
+  LAT: number;
+  STDY_OPER_BGNG_HR: string;
+  RMRK: string;
+  LHLDY_OPER_BGNG_HR: string;
+  WKDY_OPER_END_HR: string;
+};
+
+export type NearbyShelterApiResponse = NearbyShelterApiItem[];

--- a/src/features/shelter/services/shelter.ts
+++ b/src/features/shelter/services/shelter.ts
@@ -1,0 +1,29 @@
+import axios from "axios";
+import { buildApiUrl } from "@/common/utils/url";
+import type { NearbyShelterApiResponse } from "../schemas/shelter.schema";
+
+export async function fetchNearbyShelters(params: {
+  userLat: number;
+  userLot: number;
+  baseUrl?: string;
+  signal?: AbortSignal;
+}): Promise<NearbyShelterApiResponse> {
+  const { userLat, userLot, baseUrl, signal } = params;
+
+  const urlStr = buildApiUrl(baseUrl, "/shelter/winter/near");
+
+  const res = await axios.get(urlStr, {
+    headers: {
+      userLat: String(userLat),
+      userLot: String(userLot)
+    },
+    params: { userLat, userLot },
+    signal
+  });
+
+  const raw = res.data as unknown;
+  if (Array.isArray(raw)) return raw as NearbyShelterApiResponse;
+  if (raw && typeof raw === "object" && Array.isArray((raw as any).data))
+    return (raw as any).data as NearbyShelterApiResponse;
+  return [] as NearbyShelterApiResponse;
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -16,6 +16,10 @@ export default defineConfig(({ mode }) => {
         "/weather": {
           target: proxyTarget,
           changeOrigin: true
+        },
+        "/shelter": {
+          target: proxyTarget,
+          changeOrigin: true
         }
       }
     }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,10 +1,23 @@
-import { defineConfig } from "vite";
+import { defineConfig, loadEnv } from "vite";
 import react from "@vitejs/plugin-react";
 
 // https://vite.dev/config/
-export default defineConfig({
-  plugins: [react()],
-  resolve: {
-    alias: [{ find: "@", replacement: "/src" }]
-  }
+export default defineConfig(({ mode }) => {
+  const env = loadEnv(mode, process.cwd(), "");
+  const proxyTarget = env.VITE_PROXY_TARGET || "http://localhost:8080";
+
+  return {
+    plugins: [react()],
+    resolve: {
+      alias: [{ find: "@", replacement: "/src" }]
+    },
+    server: {
+      proxy: {
+        "/weather": {
+          target: proxyTarget,
+          changeOrigin: true
+        }
+      }
+    }
+  };
 });


### PR DESCRIPTION
## #️⃣연관된 이슈
> #4

## 📝작업 내용
- 날씨 조회/표시 기능과 한파 대피소 조회/표시 기능을 지도에 통합
- 포탈 기반 `Modal`, 드래그 가능한 `BottomSheet` 공용 컴포넌트 도입
- Zustand 스토어로 모달/바텀시트 상태 관리
- HTTP/URL 유틸 추가, Vite 설정 보완

### 주요 변경사항
- 날씨
  - `WeatherButton`, `WeatherModalContent`, `WeatherOverlay` 추가
  - 오늘의 날씨 조회 훅 `useTodayWeather`, 버튼 라벨 훅 `useWeatherButtonLabel`
  - 스키마/서비스/유틸: `weather.schema.ts`, `services/weather.ts`, `utils/weather.ts`
- 대피소
  - `ShelterBottomSheet`, `ShelterBottomSheetContent` 추가
  - 가까운 대피소 조회 훅 `useNearbyShelters`
  - 스키마/서비스: `shelter.schema.ts`, `services/shelter.ts`
- 공통 컴포넌트/상태
  - `Modal`, `BottomSheet`, `BottomSheetView`
  - Zustand: `useModalStore`, `useBottomSheetStore`
  - 바텀시트 드래그 인터랙션 훅: `useBottomSheetInteraction`
- 공통 유틸
  - `common/utils/http.ts`(API 유틸), `common/utils/url.ts`
- 지도 컴포넌트
  - `Map.tsx`에 날씨/대피소 UI 연동
  - `features/map/components/index.ts` 배럴 도입
- 설정/기타
  - `vite.config.ts` 설정 보완
  - `index.html` 포탈 마운트 등 마크업 보완
  - `App.tsx`에 모달/바텀시트 루트 조합


### 고려 사항
- API 엔드포인트/키: `common/utils/http.ts`/`url.ts` 사용.

### 스크린샷 (선택)

<img width="506" height="728" alt="image" src="https://github.com/user-attachments/assets/4de08731-e97f-487f-abc6-005440768814" />

