### PR TITLE
[Fix] TypeScript 빌드 에러 수정

### DIFF
--- a/src/common/components/BottomSheetView.tsx
+++ b/src/common/components/BottomSheetView.tsx
@@ -22,7 +22,6 @@ export function BottomSheetView(props: BottomSheetViewProps) {
   const {
     translateY,
     isDragging,
-    isAnimating,
     measured,
     sheetRef,
     handleRef,

--- a/src/common/hooks/useBottomSheetStore.ts
+++ b/src/common/hooks/useBottomSheetStore.ts
@@ -1,4 +1,4 @@
-import { ReactNode } from "react";
+import type { ReactNode } from "react";
 import { create } from "zustand";
 
 export type BottomSheetOptions = {

--- a/src/features/map/hooks/useCurrentPosition.ts
+++ b/src/features/map/hooks/useCurrentPosition.ts
@@ -1,10 +1,5 @@
 import { useCurrentPositionQuery, getPositionError } from "./useCurrentPositionQuery";
 
-type PositionError = {
-  type: "permission_denied" | "position_unavailable" | "timeout" | "not_supported" | "unknown";
-  message: string;
-};
-
 export function useCurrentPosition() {
   const { data, error, isLoading, refetch } = useCurrentPositionQuery();
 

--- a/src/features/map/hooks/useMapBottomSheet.tsx
+++ b/src/features/map/hooks/useMapBottomSheet.tsx
@@ -1,10 +1,7 @@
-import React, { useEffect, useRef } from "react";
+import { useEffect, useRef } from "react";
 import { useBottomSheetStore } from "@/common/hooks/useBottomSheetStore";
 import { ShelterBottomSheetContent } from "@/features/shelter";
-import type {
-  NearbyShelterApiItem,
-  NearbyShelterApiResponse
-} from "@/features/shelter/schemas/shelter.schema";
+import type { NearbyShelterApiItem } from "@/features/shelter/schemas/shelter.schema";
 
 /**
  * 지도에서 바텀시트를 관리하는 로직을 제공하는 훅

--- a/src/features/map/services/geolocation.ts
+++ b/src/features/map/services/geolocation.ts
@@ -4,8 +4,8 @@ export function getCurrentPositionOnce(options?: Options) {
   return new Promise<GeolocationPosition>((resolve, reject) => {
     if (!navigator.geolocation) {
       const error = new GeolocationPositionError();
-      error.code = 0; // UNKNOWN_ERROR
-      error.message = "Geolocation not supported";
+      Object.defineProperty(error, "code", { value: 0 }); // UNKNOWN_ERROR
+      Object.defineProperty(error, "message", { value: "Geolocation not supported" });
       reject(error);
       return;
     }

--- a/src/features/shelter/components/ShelterBottomSheetContent.tsx
+++ b/src/features/shelter/components/ShelterBottomSheetContent.tsx
@@ -3,6 +3,8 @@ import { useNavigate } from "react-router-dom";
 import type { NearbyShelterApiItem } from "../schemas/shelter.schema";
 import { useBottomSheetStore } from "@/common/hooks/useBottomSheetStore";
 
+export type ShelterItem = NearbyShelterApiItem;
+
 export function ShelterBottomSheetContent({
   items,
   error


### PR DESCRIPTION
## #️⃣연관된 이슈
#15 

# 📝작업 내용
## 🔧 TypeScript 빌드 에러 수정

### 변경 사항

TypeScript 빌드 과정에서 발생한 8개의 에러를 수정했습니다.

### 🐛 수정한 에러들

1. **사용하지 않는 변수 제거**
   - `BottomSheetView.tsx`: `isAnimating` 변수 제거
   - `useCurrentPosition.ts`: `PositionError` 타입 제거  
   - `useMapBottomSheet.tsx`: `React`, `NearbyShelterApiResponse` import 제거

2. **타입 import 수정**
   - `useBottomSheetStore.ts`: `ReactNode`를 type-only import로 변경

3. **readonly 속성 할당 에러 수정**
   - `geolocation.ts`: `Object.defineProperty`를 사용하여 readonly 속성 설정

4. **누락된 export 추가**
   - `ShelterBottomSheetContent.tsx`: `ShelterItem` 타입 export 추가

### ✅ 테스트
- [x] TypeScript 컴파일 에러 해결
- [x] 빌드 성공 확인
- [x] 기존 기능 동작 확인

### 🚀 결과
빌드가 성공적으로 완료되며, 모든 TypeScript 에러가 해결되었습니다.

```bash
✓ built in 2.76s
```