### PR TITLE
[Fix] vite.config.ts에서 process.cwd() 사용으로 인한 TypeScript 오류 수정

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,9 +1,10 @@
 import { defineConfig, loadEnv } from "vite";
 import react from "@vitejs/plugin-react";
+import { fileURLToPath, URL } from "node:url";
 
 // https://vite.dev/config/
 export default defineConfig(({ mode }) => {
-  const env = loadEnv(mode, process.cwd(), "");
+  const env = loadEnv(mode, fileURLToPath(new URL(".", import.meta.url)), "");
   const proxyTarget = env.VITE_PROXY_TARGET || "http://localhost:8080";
 
   return {


### PR DESCRIPTION
## 🐛 버그 수정

### 문제
- Vercel 배포 시 `vite.config.ts`에서 `process.cwd()` 사용으로 인한 TypeScript 오류 발생
- `Cannot find name 'process'. Do you need to install type definitions for node?` 오류

### 해결 방법
- `process.cwd()` 대신 `import.meta.url`과 `fileURLToPath`를 사용하여 현재 디렉토리 경로 획득
- Node.js 타입 정의(`@types/node`) 설치 없이도 빌드 가능하도록 개선

### 변경사항
- `vite.config.ts`에서 `process.cwd()` → `fileURLToPath(new URL(".", import.meta.url))`로 변경
- `node:url` 모듈 import 추가

### 테스트
- [x] 로컬 빌드 성공 확인
- [x] TypeScript 컴파일 오류 해결 확인