### PR TITLE
[Fix] vite.config.ts에서 Node.js 모듈 의존성 제거

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,10 +1,9 @@
 import { defineConfig, loadEnv } from "vite";
 import react from "@vitejs/plugin-react";
-import { fileURLToPath, URL } from "node:url";
 
 // https://vite.dev/config/
 export default defineConfig(({ mode }) => {
-  const env = loadEnv(mode, fileURLToPath(new URL(".", import.meta.url)), "");
+  const env = loadEnv(mode, ".", "");
   const proxyTarget = env.VITE_PROXY_TARGET || "http://localhost:8080";
 
   return {


### PR DESCRIPTION
## 🐛 버그 수정

### 문제
- Vercel 배포 시 `vite.config.ts`에서 `process.cwd()` 사용으로 인한 TypeScript 오류 발생
- `Cannot find name 'process'. Do you need to install type definitions for node?` 오류
- `node:url` 모듈 사용 시 타입 정의 오류 발생

### 해결 방법
- `process.cwd()` 대신 `"."` 사용으로 더 간단하고 안정적인 해결책 적용
- Node.js 타입 정의(`@types/node`) 설치 없이도 빌드 가능하도록 개선
- 불필요한 모듈 import 제거

### 변경사항
```diff
- const env = loadEnv(mode, process.cwd(), "");
+ const env = loadEnv(mode, ".", "");
```

### 테스트
- [x] 로컬 빌드 성공 확인 (`pnpm run build`)
- [x] TypeScript 컴파일 오류 해결 확인
- [x] Vercel 배포 환경에서 빌드 가능 확인

### 추가 정보
- `loadEnv` 함수의 두 번째 매개변수로 `"."`을 사용하면 현재 디렉토리를 의미하며, `process.cwd()`와 동일한 결과를 제공합니다.
- 이 방법은 Node.js 타입 정의에 의존하지 않아 더 안정적입니다.