### PR TITLE
[Fix] Vercel 배포 후 새로고침 시 404 에러 해결

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,3 @@
+{
+  "rewrites": [{ "source": "/(.*)", "destination": "/" }]
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -13,6 +13,7 @@ export default defineConfig(({ mode }) => {
     },
     server: {
       host: true,
+      historyApiFallback: true,
       proxy: {
         "/weather": {
           target: proxyTarget,


### PR DESCRIPTION
# 🐛 Fix: Vercel 배포 후 새로고침 시 404 에러 해결
React Router 기반의 SPA(Single Page Application) 프로젝트에서 특정 경로로 접근하거나 새로고침을 누르면 404 NOT_FOUND 에러가 발생하는 문제가 있었습니다.

**프로젝트 구조:**
- React Router를 사용해 클라이언트 측 라우팅을 구현
- 주요 페이지: `/` (Login), `/signup`, `/map`, `/detail`
- 환경: 개발 서버 (Vite), 배포 서버 (Vercel)

## 문제
브라우저 새로고침 또는 URL 직접 접근 시 404 NOT_FOUND 에러 발생

**예시:**
- 사용자가 `/map` 페이지로 직접 접근 → 404 에러
- `/detail` 페이지에서 새로고침 → 404 에러

## 원인

### 1. SPA 특성
SPA(Single Page Application)는 브라우저에서 하나의 `index.html` 파일을 기반으로 동작하는 웹 애플리케이션입니다.

**페이지 이동 처리 방식:**
- SPA는 클라이언트 측에서 페이지를 동적으로 렌더링
- React Router와 같은 라이브러리를 사용하여 URL 경로와 컴포넌트를 연결
- JavaScript를 통해 페이지 내용을 업데이트 (실제 페이지 리로드 없음)
- 모든 경로(`/`, `/map`, `/detail`)는 실제로는 같은 `index.html` 파일을 사용

### 2. 서버의 동작 방식
브라우저가 서버와 통신하는 경우(새로고침, 직접 URL 입력)에는 서버가 관여하게 되며, 이 과정에서 문제가 발생합니다.

**문제 발생 과정:**
1. 사용자가 `/map` 경로를 새로고침하거나 직접 접근
2. 브라우저는 서버에 `/map` 경로로 HTTP GET 요청을 보냄
3. 서버는 파일 시스템에서 `/map` 경로에 해당하는 파일을 찾음
4. 해당 리소스가 존재하지 않으므로, 서버는 404 NOT_FOUND 에러를 반환
5. React Router는 서버 에러를 처리할 수 없으므로 정상적으로 렌더링되지 않음

## 해결 방법

### 1️⃣ Vite 개발 서버에서의 설정
**해결책:** Vite의 `historyApiFallback` 설정을 활성화하여 서버가 모든 요청을 `index.html`로 리디렉션하도록 구성

```typescript
// vite.config.ts
server: {
  host: true,
  historyApiFallback: true, // SPA 라우팅을 위한 설정
  proxy: {
    // ... 기존 proxy 설정
  }
}
```

### 2️⃣ 배포 환경에서의 설정 (Vercel 기준)
**해결책:** Vercel에서 모든 경로에 대해 `index.html`을 반환하도록 리디렉션 설정

```json
// vercel.json
{
  "rewrites": [{ "source": "/(.*)", "destination": "/" }]
}
```

**작동 원리:**
- Vercel은 사용자가 `/map`으로 접근하면 해당 요청을 `/index.html`로 리디렉션
- 클라이언트 측에서 React Router가 해당 경로를 처리

## 기대 결과
위 설정을 통해 브라우저 새로고침 및 URL 직접 접근 시에도 서버가 `index.html`을 반환하며, React Router가 정상적으로 경로를 처리할 수 있게 됩니다.

**예상 해결 내용:**
- ✅ 404 NOT_FOUND 에러 해결
- ✅ 클라이언트에서 올바른 컴포넌트 렌더링
- ✅ 개발 환경과 배포 환경 모두에서 SPA 라우팅 정상 동작

## 변경 사항
- `vite.config.ts`: `historyApiFallback: true` 설정 추가
- `vercel.json`: SPA 라우팅을 위한 rewrites 설정 추가
