### PR TITLE
[Fix] VITE_API_BASE_URL로 production API base URL 설정

### DIFF
--- a/src/features/map/services/weather.ts
+++ b/src/features/map/services/weather.ts
@@ -9,7 +9,8 @@ export async function fetchTodayWeather(params: {
 }) {
   const { userLat, userLot, baseUrl, signal } = params;
 
-  const urlStr = buildApiUrl(baseUrl, "/weather/today");
+  const apiBase = import.meta.env.VITE_API_BASE_URL || baseUrl;
+  const urlStr = buildApiUrl(apiBase, "/weather/today");
 
   const res = await axios.get(urlStr, {
     headers: {

--- a/src/features/shelter/services/shelter.ts
+++ b/src/features/shelter/services/shelter.ts
@@ -13,7 +13,8 @@ export async function fetchNearbyShelters(params: {
 
   const season = getCurrentSeason();
   const endpoint = season === "summer" ? "/shelter/summer/near" : "/shelter/winter/near";
-  const urlStr = buildApiUrl(baseUrl, endpoint);
+  const apiBase = import.meta.env.VITE_API_BASE_URL || baseUrl;
+  const urlStr = buildApiUrl(apiBase, endpoint);
 
   const res = await axios.get(urlStr, {
     headers: {


### PR DESCRIPTION
## 🚀 배포 환경에서 API 호출 동작하도록 환경변수 기반 설정 추가

### 문제 상황
- 로컬에서는 `vite.config.ts`의 proxy 설정으로 API 호출이 정상 동작
- 배포 환경(Vercel)에서는 proxy가 동작하지 않아 `/weather/...`, `/shelter/...` 요청이 SPA HTML만 반환

### 🔧 해결 방법
환경변수 기반의 절대 URL 사용으로 변경하여 로컬/배포 환경 모두에서 동일한 코드로 동작하도록 개선

### 📝 변경사항
#### 1. API 서비스 수정
- **`src/features/map/services/weather.ts`**
  - `VITE_API_BASE_URL` 환경변수 사용
  - 로컬: `baseUrl` fallback으로 proxy 유지
  - 배포: 절대 URL로 직접 API 호출

- **`src/features/shelter/services/shelter.ts`**
  - 동일한 환경변수 패턴 적용

#### 2. 설정 파일 정리
- **`vercel.json`**: SPA fallback만 유지 (서버리스 리라이트 제거)
- **`api/weather/today.ts`**: 서버리스 함수 삭제

---
**Related**: 배포 후 API 응답 없음 이슈 해결