### PR TITLE
[Fix] 배포 환경에서 날씨 API 요청 오류 수정

### DIFF
--- a/src/features/map/components/WeatherModalContent.tsx
+++ b/src/features/map/components/WeatherModalContent.tsx
@@ -5,11 +5,13 @@ import { normalizeTemp, toSkyKorean, toPtyKorean } from "../utils/weather";
 export function WeatherModalContent({
   weather,
   loading,
-  error
+  error,
+  rawResponse
 }: {
   weather: TodayWeatherResponse | null;
   loading?: boolean;
   error?: string | null;
+  rawResponse?: unknown;
 }) {
   return (
     <>
@@ -18,7 +20,33 @@ export function WeatherModalContent({
       </div>
       <div className={styles.contentScroll}>
         {loading && <div>불러오는 중...</div>}
-        {error && !loading && <div style={{ color: "#ef4444" }}>오류: {error}</div>}
+        {error && !loading && (
+          <div style={{ color: "#ef4444" }}>
+            <div>오류: {error}</div>
+            {error.startsWith("데이터 파싱 오류") && (
+              <div style={{ fontSize: "12px", marginTop: "8px", opacity: 0.8 }}>
+                서버에서 받은 데이터 형식이 예상과 다릅니다. 잠시 후 다시 시도해주세요.
+              </div>
+            )}
+            {import.meta.env.DEV && (
+              <details style={{ marginTop: "8px", fontSize: "10px" }}>
+                <summary>개발자 정보 (개발 환경에서만 표시)</summary>
+                <pre
+                  style={{
+                    background: "#f5f5f5",
+                    padding: "8px",
+                    marginTop: "4px",
+                    fontSize: "10px",
+                    overflow: "auto",
+                    maxHeight: "200px"
+                  }}
+                >
+                  {error}
+                </pre>
+              </details>
+            )}
+          </div>
+        )}
         {!loading && !error && weather && (
           <>
             <div className={styles.hero}>

--- a/src/features/map/hooks/useWeatherButtonLabel.ts
+++ b/src/features/map/hooks/useWeatherButtonLabel.ts
@@ -9,7 +9,13 @@ export function useWeatherButtonLabel(
 ) {
   return useMemo(() => {
     if (loading) return "불러오는 중...";
-    if (error) return "오류";
+    if (error) {
+      // 에러 메시지가 "데이터 파싱 오류"로 시작하는 경우 더 구체적인 메시지 표시
+      if (error.startsWith("데이터 파싱 오류")) {
+        return "데이터 오류";
+      }
+      return "오류";
+    }
     if (!weather) return "날씨 없음";
     const temp = normalizeTemp(weather.tmp);
     return temp;

--- a/src/features/map/schemas/weather.schema.ts
+++ b/src/features/map/schemas/weather.schema.ts
@@ -18,7 +18,10 @@ export type TodayWeatherResponse = {
 };
 
 export function isTodayWeatherResponse(input: unknown): input is TodayWeatherResponse {
-  if (typeof input !== "object" || input === null) return false;
+  if (typeof input !== "object" || input === null) {
+    console.log("날씨 스키마 검증 실패: input이 객체가 아님", typeof input, input);
+    return false;
+  }
   const obj = input as Record<string, unknown>;
   const requiredStringFields = [
     "baseDate",
@@ -37,9 +40,19 @@ export function isTodayWeatherResponse(input: unknown): input is TodayWeatherRes
     "pcp"
   ];
   for (const key of requiredStringFields) {
-    if (typeof obj[key] !== "string") return false;
+    if (typeof obj[key] !== "string") {
+      console.log(`날씨 스키마 검증 실패: ${key} 필드가 문자열이 아님`, typeof obj[key], obj[key]);
+      return false;
+    }
   }
-  if (typeof obj["nx"] !== "number" || typeof obj["ny"] !== "number") return false;
+  if (typeof obj["nx"] !== "number" || typeof obj["ny"] !== "number") {
+    console.log(
+      "날씨 스키마 검증 실패: nx 또는 ny가 숫자가 아님",
+      typeof obj["nx"],
+      typeof obj["ny"]
+    );
+    return false;
+  }
   return true;
 }
 

--- a/src/features/map/services/weather.ts
+++ b/src/features/map/services/weather.ts
@@ -12,6 +12,10 @@ export async function fetchTodayWeather(params: {
   const apiBase = import.meta.env.VITE_API_BASE_URL || baseUrl;
   const urlStr = buildApiUrl(apiBase, "/weather/today");
 
+  // 배포 환경에서 URL 확인을 위한 로깅
+  console.log("날씨 API 요청 URL:", urlStr);
+  console.log("VITE_API_BASE_URL:", import.meta.env.VITE_API_BASE_URL);
+
   const res = await axios.get(urlStr, {
     headers: {
       userLat: String(userLat),

--- a/vercel.json
+++ b/vercel.json
@@ -1,7 +1,3 @@
 {
-  "rewrites": [{ "source": "/(.*)", "destination": "/" }],
-  "env": {
-    "VITE_API_BASE_URL": "https://your-api-server.com",
-    "VITE_MEMBER_API_URL": "https://your-member-api-server.com"
-  }
+  "rewrites": [{ "source": "/(.*)", "destination": "/" }]
 }

--- a/vercel.json
+++ b/vercel.json
@@ -1,3 +1,7 @@
 {
-  "rewrites": [{ "source": "/(.*)", "destination": "/" }]
+  "rewrites": [{ "source": "/(.*)", "destination": "/" }],
+  "env": {
+    "VITE_API_BASE_URL": "https://your-api-server.com",
+    "VITE_MEMBER_API_URL": "https://your-member-api-server.com"
+  }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈
#26 

## 📝작업 내용
### 🐛 문제 상황
- 배포 환경에서 날씨 API 요청이 200으로 성공하지만 날씨 데이터가 '오류'로 표시됨
- 개발 환경에서는 정상 작동하지만 배포 환경에서만 발생하는 문제

### 원인 분석
- **개발 환경**: Vite 프록시 설정으로 `/weather` 요청이 `proxyTarget`으로 전달됨
- **배포 환경**: `VITE_API_BASE_URL` 환경 변수가 설정되지 않아 상대 경로 `/weather/today`로 잘못된 요청 발생
- 배포된 사이트 도메인으로 API 요청이 가면서 404 또는 잘못된 응답 반환

### 해결 방법
1. **환경 변수 설정 추가**
   - 배포 환경에서 올바른 API 서버 URL 사용

2. **디버깅 로깅 추가**
   - 날씨 API 서비스에 요청 URL 로깅 추가
   - 배포 환경에서 실제 요청 URL 확인 가능

### 📝 변경사항
- `src/features/map/services/weather.ts`: API 요청 URL 디버깅 로깅 추가
- `src/features/map/schemas/weather.schema.ts`: 스키마 검증 로직 정리
- `src/features/map/hooks/useTodayWeather.ts`: 에러 처리 로직 정리
- `src/features/map/components/WeatherModalContent.tsx`: 에러 표시 개선
- `src/features/map/hooks/useWeatherButtonLabel.ts`: 에러 메시지 개선

###  테스트
- [ ] 개발 환경에서 날씨 API 정상 작동 확인
- [ ] 배포 환경에서 환경 변수 설정 후 날씨 데이터 정상 표시 확인
- [ ] 브라우저 콘솔에서 올바른 API URL 요청 확인

### 📋 추가 작업 필요
 **문제 해결 후 디버깅 로그 제거**
