### PR TITLE
[Fix] 바텀시트 초기 렌더링 시 위치 오류 및 터치 불가 문제 해결

### DIFF
--- a/src/common/hooks/useBottomSheetInteraction.ts
+++ b/src/common/hooks/useBottomSheetInteraction.ts
@@ -25,8 +25,8 @@ export function useBottomSheetInteraction(peekHeight: number) {
   const maxTranslateRef = useRef(0);
   const animationFrameRef = useRef<number | null>(null);
 
-  const initialTranslate = Math.max(Math.round(window.innerHeight * 0.7) - peekHeight, 0);
-  const [translateY, setTranslateY] = useState(initialTranslate);
+  // 초기값을 큰 값으로 설정하여 처음부터 화면 밖에 위치
+  const [translateY, setTranslateY] = useState(1000);
   const [isDragging, setIsDragging] = useState(false);
   const [isAnimating, setIsAnimating] = useState(false);
   const [measured, setMeasured] = useState(false);
@@ -34,32 +34,127 @@ export function useBottomSheetInteraction(peekHeight: number) {
   const recalc = useCallback(() => {
     const el = sheetRef.current;
     if (!el) return;
-    const h = el.getBoundingClientRect().height;
+
+    // ResizeObserver나 getBoundingClientRect를 사용하여 정확한 높이 측정
+    const rect = el.getBoundingClientRect();
+    const h = rect.height;
+
+    if (h === 0) {
+      // 아직 높이가 측정되지 않았다면 다음 프레임에서 재시도
+      requestAnimationFrame(() => recalc());
+      return;
+    }
+
     const maxTranslate = Math.max(h - peekHeight, 0);
     maxTranslateRef.current = maxTranslate;
+
+    // 항상 바텀 위치로 설정 (measured 상태와 관계없이)
     setTranslateY(maxTranslate);
-    setMeasured(true);
-  }, [peekHeight]);
+
+    if (!measured) {
+      setMeasured(true);
+    }
+  }, [peekHeight, measured]);
 
   useEffect(() => {
-    recalc();
-    const onResize = () => recalc();
+    // 초기 측정은 DOM이 완전히 렌더링된 후 실행
+    const measureInitial = () => {
+      // 여러 프레임에 걸쳐 측정 시도
+      let attempts = 0;
+      const maxAttempts = 10;
+
+      const tryMeasure = () => {
+        const el = sheetRef.current;
+        if (!el) {
+          if (attempts < maxAttempts) {
+            attempts++;
+            requestAnimationFrame(tryMeasure);
+          }
+          return;
+        }
+
+        const rect = el.getBoundingClientRect();
+        if (rect.height === 0 && attempts < maxAttempts) {
+          attempts++;
+          requestAnimationFrame(tryMeasure);
+          return;
+        }
+
+        recalc();
+      };
+
+      requestAnimationFrame(tryMeasure);
+    };
+
+    measureInitial();
+
+    // ResizeObserver를 사용하여 더 정확한 크기 변경 감지
+    const resizeObserver = new ResizeObserver(() => {
+      // measured가 true일 때만 recalc 호출하여 불필요한 재계산 방지
+      if (measured) {
+        const el = sheetRef.current;
+        if (!el) return;
+
+        const rect = el.getBoundingClientRect();
+        const h = rect.height;
+
+        if (h > 0) {
+          const maxTranslate = Math.max(h - peekHeight, 0);
+          maxTranslateRef.current = maxTranslate;
+
+          // 현재 위치가 collapsed 상태라면 새로운 바텀 위치로 업데이트
+          if (translateY >= maxTranslateRef.current * 0.8) {
+            setTranslateY(maxTranslate);
+          }
+        }
+      }
+    });
+
+    if (sheetRef.current) {
+      resizeObserver.observe(sheetRef.current);
+    }
+
+    // 윈도우 리사이즈 이벤트도 유지
+    const onResize = () => {
+      if (measured) {
+        const el = sheetRef.current;
+        if (!el) return;
+
+        const rect = el.getBoundingClientRect();
+        const h = rect.height;
+
+        if (h > 0) {
+          const maxTranslate = Math.max(h - peekHeight, 0);
+          maxTranslateRef.current = maxTranslate;
+
+          // 현재 위치가 collapsed 상태라면 새로운 바텀 위치로 업데이트
+          if (translateY >= maxTranslateRef.current * 0.8) {
+            setTranslateY(maxTranslate);
+          }
+        }
+      }
+    };
+
     window.addEventListener("resize", onResize);
+
     return () => {
+      resizeObserver.disconnect();
       window.removeEventListener("resize", onResize);
       if (animationFrameRef.current) {
         cancelAnimationFrame(animationFrameRef.current);
       }
     };
-  }, [recalc]);
+  }, [recalc, measured]);
 
   const onPointerDown = (e: React.PointerEvent) => {
-    if (e.button !== 0) return;
+    // 측정이 완료되지 않았으면 동작하지 않음
+    if (!measured || e.button !== 0) return;
     e.preventDefault();
 
     if (animationFrameRef.current) {
       cancelAnimationFrame(animationFrameRef.current);
       animationFrameRef.current = null;
+      setIsAnimating(false);
     }
 
     setIsDragging(true);
@@ -69,26 +164,29 @@ export function useBottomSheetInteraction(peekHeight: number) {
   };
 
   const onPointerMove = (e: React.PointerEvent) => {
-    if (!isDragging) return;
+    if (!isDragging || !measured) return;
     const dy = e.clientY - startYRef.current;
     const next = Math.min(Math.max(startTranslateRef.current + dy, 0), maxTranslateRef.current);
     setTranslateY(next);
   };
 
   const onPointerUp = () => {
-    if (!isDragging) return;
+    if (!isDragging || !measured) return;
     setIsDragging(false);
     const over = maxTranslateRef.current;
     const snapTo = translateY < over / 2 ? 0 : over;
-    setTranslateY(snapTo);
+
+    // 애니메이션으로 스냅
+    animateToPosition(snapTo);
   };
 
   const onTouchStart = (e: React.TouchEvent) => {
-    if (e.touches.length === 0) return;
+    if (!measured || e.touches.length === 0) return;
 
     if (animationFrameRef.current) {
       cancelAnimationFrame(animationFrameRef.current);
       animationFrameRef.current = null;
+      setIsAnimating(false);
     }
 
     setIsDragging(true);
@@ -98,7 +196,7 @@ export function useBottomSheetInteraction(peekHeight: number) {
   };
 
   const onTouchMove = (e: React.TouchEvent) => {
-    if (!isDragging || e.touches.length === 0) return;
+    if (!isDragging || !measured || e.touches.length === 0) return;
     const touch = e.touches[0];
     const dy = touch.clientY - startYRef.current;
     const next = Math.min(Math.max(startTranslateRef.current + dy, 0), maxTranslateRef.current);
@@ -106,80 +204,59 @@ export function useBottomSheetInteraction(peekHeight: number) {
   };
 
   const onTouchEnd = () => {
-    if (!isDragging) return;
+    if (!isDragging || !measured) return;
     setIsDragging(false);
     const over = maxTranslateRef.current;
     const snapTo = translateY < over / 2 ? 0 : over;
-    setTranslateY(snapTo);
+
+    // 애니메이션으로 스냅
+    animateToPosition(snapTo);
   };
 
-  const expandToTop = useCallback(() => {
-    if (isDragging) return;
-
-    if (animationFrameRef.current) {
-      cancelAnimationFrame(animationFrameRef.current);
-    }
-
-    setIsAnimating(true);
-
-    const startY = translateY;
-    const targetY = 0;
-    const duration = 300;
-    const startTime = performance.now();
-
-    const animate = (currentTime: number) => {
-      const elapsed = currentTime - startTime;
-      const progress = Math.min(elapsed / duration, 1);
-
-      const easeOutCubic = 1 - Math.pow(1 - progress, 3);
-      const currentY = startY + (targetY - startY) * easeOutCubic;
-
-      setTranslateY(currentY);
-
-      if (progress < 1) {
-        animationFrameRef.current = requestAnimationFrame(animate);
-      } else {
-        animationFrameRef.current = null;
-        setIsAnimating(false);
+  // 공통 애니메이션 함수
+  const animateToPosition = useCallback(
+    (targetY: number) => {
+      if (animationFrameRef.current) {
+        cancelAnimationFrame(animationFrameRef.current);
       }
-    };
 
-    animationFrameRef.current = requestAnimationFrame(animate);
-  }, [translateY, isDragging]);
+      setIsAnimating(true);
+
+      const startY = translateY;
+      const duration = 300;
+      const startTime = performance.now();
+
+      const animate = (currentTime: number) => {
+        const elapsed = currentTime - startTime;
+        const progress = Math.min(elapsed / duration, 1);
+
+        const easeOutCubic = 1 - Math.pow(1 - progress, 3);
+        const currentY = startY + (targetY - startY) * easeOutCubic;
+
+        setTranslateY(currentY);
+
+        if (progress < 1) {
+          animationFrameRef.current = requestAnimationFrame(animate);
+        } else {
+          animationFrameRef.current = null;
+          setIsAnimating(false);
+        }
+      };
+
+      animationFrameRef.current = requestAnimationFrame(animate);
+    },
+    [translateY]
+  );
+
+  const expandToTop = useCallback(() => {
+    if (isDragging || !measured) return;
+    animateToPosition(0);
+  }, [isDragging, measured, animateToPosition]);
 
   const collapseToBottom = useCallback(() => {
-    if (isDragging) return;
-
-    if (animationFrameRef.current) {
-      cancelAnimationFrame(animationFrameRef.current);
-    }
-
-    setIsAnimating(true);
-
-    const startY = translateY;
-    const targetY = maxTranslateRef.current;
-    const duration = 300;
-    const startTime = performance.now();
-
-    const animate = (currentTime: number) => {
-      const elapsed = currentTime - startTime;
-      const progress = Math.min(elapsed / duration, 1);
-
-      const easeOutCubic = 1 - Math.pow(1 - progress, 3);
-      const currentY = startY + (targetY - startY) * easeOutCubic;
-
-      setTranslateY(currentY);
-
-      if (progress < 1) {
-        animationFrameRef.current = requestAnimationFrame(animate);
-      } else {
-        animationFrameRef.current = null;
-        setIsAnimating(false);
-      }
-    };
-
-    animationFrameRef.current = requestAnimationFrame(animate);
-  }, [translateY, isDragging]);
+    if (isDragging || !measured) return;
+    animateToPosition(maxTranslateRef.current);
+  }, [isDragging, measured, animateToPosition]);
 
   return {
     sheetRef,

--- a/src/features/map/services/weather.ts
+++ b/src/features/map/services/weather.ts
@@ -28,16 +28,6 @@ export async function fetchTodayWeather(params: {
 
   const urlStr = buildApiUrl(apiBase, "/weather/today");
 
-  // 배포 환경에서 URL 확인을 위한 로깅
-  console.log("날씨 API 요청 URL:", urlStr);
-  console.log("VITE_API_BASE_URL:", import.meta.env.VITE_API_BASE_URL);
-  console.log(
-    "모든 VITE_ 환경 변수:",
-    Object.keys(import.meta.env).filter(key => key.startsWith("VITE_"))
-  );
-  console.log("현재 모드:", import.meta.env.MODE);
-  console.log("개발 모드인가?", import.meta.env.DEV);
-
   const res = await axios.get(urlStr, {
     headers: {
       userLat: String(userLat),


### PR DESCRIPTION
## #️⃣연관된 이슈
#30 

## 📝작업 내용
1. **ResizeObserver 사용**: 
   - DOM 크기 변경을 더 정확하게 감지
   - `getBoundingClientRect`만으로는 놓칠 수 있는 변화들을 포착

2. **다중 프레임 측정**:
   - `requestAnimationFrame`을 여러 번 사용하여 DOM이 완전히 렌더링될 때까지 기다림
   - 높이가 0일 때 재시도하는 로직

3. **measured 상태 기반 제어**:
   - 측정이 완료되지 않았을 때는 터치/드래그 동작을 막음
   - 불필요한 재계산을 방지

4. **공통 애니메이션 함수**:
   - `animateToPosition` 함수로 코드 중복 제거
   - 더 깔끔하고 유지보수하기 쉬운 구조

5. **위치 업데이트**:
   - collapsed 상태일 때만 새로운 바텀 위치로 업데이트
   - 불필요한 위치 변경 방지
