### PR TITLE
[Fix] 비밀번호 토글 수정

### DIFF
--- a/src/common/components/input/Input.tsx
+++ b/src/common/components/input/Input.tsx
@@ -20,7 +20,7 @@ export default function Input({ Icon, secureTextEntry: secureEntryProp, ...props
       <input
         className={`${styles.input} ${Icon ? styles.hasIcon : ""}`}
         {...props}
-        type={secureTextEntry ? "password" : props.type || "text"}
+        type={secureEntryProp ? (secureTextEntry ? "password" : "text") : props.type || "text"}
       />
 
       {secureEntryProp && (

--- a/src/features/user/components/login/Login.tsx
+++ b/src/features/user/components/login/Login.tsx
@@ -33,9 +33,8 @@ export default function Login() {
         <Input
           Icon={FaLock}
           placeholder="비밀번호"
-          type="password"
-          {...register("memberPassword")}
           secureTextEntry
+          {...register("memberPassword")}
         />
         {mutation.isError && (
           <div className={styles.error}>아이디 또는 비밀번호가 올바르지 않습니다.</div>


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #31 

## 문제
- 로그인 화면에서 비밀번호 입력 필드에 눈 아이콘은 보이지만, 토글해도 입력값이 노출되지 않음.
- 회원가입 화면에서는 정상 동작.

## 원인
- 로그인에서는 <Input />에 type="password"를 직접 넘겼음.
- Input 내부에서 이미 secureTextEntry 기반으로 type을 "password" ↔ "text"로 관리하고 있었는데, 외부 type과 충돌이 생김.

## 해결
- 로그인 화면에서 type="password" 제거 → secureTextEntry만 넘기도록 수정.
- Input 내부 로직 강화
  - `type={secureEntryProp ? (secureTextEntry ? "password" : "text") : props.type || "text"}`
    - 이제 secureTextEntry가 true일 때만 비밀번호 토글 로직을 적용.
    - 그렇지 않은 경우에는 기존처럼 props.type을 그대로 사용.

## 기대 효과
- 로그인 화면에서도 비밀번호 표시/숨기기 토글 정상 작동.
- 외부에서 type을 잘못 넘겨도 충돌 없이 동작.