### PR TITLE
Fix: 바텀시트 초기 진입 시 동작 안 함 이슈 해결 및 불필요한 기능 제거

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,6 @@
 import styles from "./App.module.css";
 import { Map } from "@/features/map";
 import { Modal } from "@/common/components/Modal";
-import { BottomSheet } from "@/common/components/BottomSheet";
 import { Login } from "@/features/user";
 import { SignUp } from "@/features/user";
 import { BrowserRouter as Router, Routes, Route } from "react-router-dom";
@@ -21,7 +20,6 @@ function App() {
             <Route path="/detail" element={<ShelterDetail />} />
           </Routes>
           <Modal />
-          <BottomSheet />
         </Router>
       </div>
     </QueryClientProvider>

--- a/src/common/components/BottomSheet.tsx
+++ b/src/common/components/BottomSheet.tsx
@@ -63,14 +63,6 @@ export function BottomSheet() {
       onTouchStart={interaction.onTouchStart}
       onTouchMove={interaction.onTouchMove}
       onTouchEnd={interaction.onTouchEnd}
-      onBackdropClick={() =>
-        useBottomSheetStore.setState({
-          content: null,
-          ariaLabel: null,
-          expandToTop: null,
-          collapseToBottom: null
-        })
-      }
       ariaLabel={ariaLabel ?? undefined}
     >
       {content}

--- a/src/common/components/BottomSheetView.tsx
+++ b/src/common/components/BottomSheetView.tsx
@@ -13,7 +13,6 @@ export type BottomSheetViewProps = {
   onTouchStart: (e: React.TouchEvent) => void;
   onTouchMove: (e: React.TouchEvent) => void;
   onTouchEnd: () => void;
-  onBackdropClick: () => void;
   ariaLabel?: string;
   children?: React.ReactNode;
 };
@@ -31,13 +30,12 @@ export function BottomSheetView(props: BottomSheetViewProps) {
     onTouchStart,
     onTouchMove,
     onTouchEnd,
-    onBackdropClick,
     ariaLabel,
     children
   } = props;
 
   return (
-    <div className={styles.backdrop} onClick={onBackdropClick}>
+    <div className={styles.backdrop}>
       <div
         ref={sheetRef}
         className={`${styles.sheetWrapper} ${isDragging ? styles.dragging : ""} ${!measured ? styles.noTransition : ""}`}

--- a/src/common/hooks/useBottomSheetStore.ts
+++ b/src/common/hooks/useBottomSheetStore.ts
@@ -1,35 +1,20 @@
 import type { ReactNode } from "react";
 import { create } from "zustand";
 
-export type BottomSheetOptions = {
-  onBackdropClick?: () => void;
-  ariaLabel?: string;
-};
-
 interface BottomSheetStore {
-  isOpen: boolean;
   content: ReactNode | null;
-  options: BottomSheetOptions | null;
+  ariaLabel: string | null;
   translateY: number;
-  open: (content: ReactNode, options?: BottomSheetOptions) => void;
-  openAndExpand: (content: ReactNode, options?: BottomSheetOptions) => void;
-  setTranslateY: (translateY: number) => void;
-  close: () => void;
+  setContent: (content: ReactNode, ariaLabel?: string) => void;
   expandToTop: (() => void) | null;
   collapseToBottom: (() => void) | null;
 }
 
 export const useBottomSheetStore = create<BottomSheetStore>(set => ({
-  isOpen: false,
   content: null,
-  options: null,
+  ariaLabel: null,
   translateY: 0,
-  open: (content, options) => set({ isOpen: true, content, options: options ?? null }),
-  openAndExpand: (content, options) => {
-    set({ isOpen: true, content, options: options ?? null, translateY: 0 });
-  },
-  setTranslateY: translateY => set({ translateY }),
-  close: () => set({ isOpen: false, content: null, options: null }),
+  setContent: (content, ariaLabel) => set({ content, ariaLabel: ariaLabel ?? null }),
   expandToTop: null,
   collapseToBottom: null
 }));

--- a/src/features/map/components/Map.tsx
+++ b/src/features/map/components/Map.tsx
@@ -8,6 +8,7 @@ import { PositionLoadingOverlay } from "./PositionLoadingOverlay";
 import { useNearbyShelters } from "@/features/shelter";
 import { useModalStore } from "@/common/hooks/useModalStore";
 import { useEffect, useRef } from "react";
+import { BottomSheet } from "@/common/components/BottomSheet";
 import { useRouteStore } from "@/features/route/hooks/useRouteStore";
 import { useRoutePath } from "@/features/route/services/useRoutePath";
 
@@ -56,10 +57,7 @@ export default function Map() {
             }}
             onClose={close}
           />,
-          {
-            ariaLabel: "위치 정보 오류",
-            onBackdropClick: close
-          }
+          "위치 정보 오류"
         );
       }
     } else if (!positionError) {
@@ -68,68 +66,71 @@ export default function Map() {
     }
   }, [positionError, isLoading, open, close, retry]);
 
-  if (!apiKey || !isLoaded) return null;
+  if (!apiKey) return null;
 
   return (
     <>
-      <GoogleMap
-        mapContainerStyle={{ width: "100%", height: "100%" }}
-        center={position ?? DEFAULT_CENTER}
-        zoom={position ? 15 : 12}
-        options={{ fullscreenControl: false, streetViewControl: false, mapTypeControl: false }}
-      >
-        {routeData?.route?.traoptimal?.[0]?.path?.length &&
-          routeData.route.traoptimal[0].path!.length > 0 && (
-            <Polyline
-              path={routeData.route.traoptimal[0].path.map(([lng, lat]: [number, number]) => ({
-                lat,
-                lng
-              }))}
-              options={{ strokeColor: "#0f3cc5ff", strokeWeight: 4 }}
+      {isLoaded && (
+        <GoogleMap
+          mapContainerStyle={{ width: "100%", height: "100%" }}
+          center={position ?? DEFAULT_CENTER}
+          zoom={position ? 15 : 12}
+          options={{ fullscreenControl: false, streetViewControl: false, mapTypeControl: false }}
+        >
+          {routeData?.route?.traoptimal?.[0]?.path?.length &&
+            routeData.route.traoptimal[0].path!.length > 0 && (
+              <Polyline
+                path={routeData.route.traoptimal[0].path.map(([lng, lat]: [number, number]) => ({
+                  lat,
+                  lng
+                }))}
+                options={{ strokeColor: "#0f3cc5ff", strokeWeight: 4 }}
+              />
+            )}
+
+          {position && (
+            <WeatherOverlay
+              weather={weather}
+              loading={loading}
+              error={error}
+              shelters={shelters}
+              sheltersError={sheltersError}
             />
           )}
 
-        {position && (
-          <WeatherOverlay
-            weather={weather}
-            loading={loading}
-            error={error}
-            shelters={shelters}
-            sheltersError={sheltersError}
-          />
-        )}
+          {position && accuracy != null && (
+            <Circle
+              center={position}
+              radius={accuracy}
+              options={{
+                fillColor: "#487fee9b",
+                fillOpacity: 0.2,
+                strokeColor: "#487fee9b",
+                strokeOpacity: 0.4,
+                strokeWeight: 1,
+                clickable: false
+              }}
+            />
+          )}
+          {position && (
+            <Circle
+              center={position}
+              radius={6}
+              options={{
+                fillColor: "#4880EE",
+                fillOpacity: 1,
+                strokeColor: "#ffffff",
+                strokeOpacity: 1,
+                strokeWeight: 3,
+                clickable: false
+              }}
+            />
+          )}
+        </GoogleMap>
+      )}
 
-        {position && accuracy != null && (
-          <Circle
-            center={position}
-            radius={accuracy}
-            options={{
-              fillColor: "#487fee9b",
-              fillOpacity: 0.2,
-              strokeColor: "#487fee9b",
-              strokeOpacity: 0.4,
-              strokeWeight: 1,
-              clickable: false
-            }}
-          />
-        )}
-        {position && (
-          <Circle
-            center={position}
-            radius={6}
-            options={{
-              fillColor: "#4880EE",
-              fillOpacity: 1,
-              strokeColor: "#ffffff",
-              strokeOpacity: 1,
-              strokeWeight: 3,
-              clickable: false
-            }}
-          />
-        )}
-      </GoogleMap>
-
-      {isLoading && <PositionLoadingOverlay />}
+      {/* {isLoading && <PositionLoadingOverlay />} */}
+      <BottomSheet />
     </>
   );
 }

--- a/src/features/map/hooks/useMapBottomSheet.tsx
+++ b/src/features/map/hooks/useMapBottomSheet.tsx
@@ -12,30 +12,33 @@ export function useMapBottomSheet(
   shelters: NearbyShelterApiItem[] | null,
   sheltersError: string | null
 ) {
-  const { open } = useBottomSheetStore();
+  const { setContent } = useBottomSheetStore();
   const openedOnceRef = useRef(false);
 
+  // 초기 진입 시, 지도 로드 여부와 무관하게 한 번 비어있는 리스트를 노출
+  useEffect(() => {
+    if (!openedOnceRef.current && !position) {
+      setContent(<ShelterBottomSheetContent items={[]} />, "대피소 목록");
+      openedOnceRef.current = true;
+    }
+  }, []);
+
+  // 지도 로드 이후 데이터/에러에 따라 내용 업데이트
   useEffect(() => {
     if (!isLoaded) return;
 
-    if (!position && !openedOnceRef.current) {
-      open(<ShelterBottomSheetContent items={[]} />, { ariaLabel: "대피소 목록" });
-      openedOnceRef.current = true;
-      return;
-    }
-
     if (sheltersError) {
-      open(<ShelterBottomSheetContent error={sheltersError} />, { ariaLabel: "대피소 목록" });
+      setContent(<ShelterBottomSheetContent error={sheltersError} />, "대피소 목록");
       openedOnceRef.current = true;
       return;
     }
 
     if (shelters && Array.isArray(shelters)) {
       const items = Array.isArray(shelters) ? shelters : [];
-      open(<ShelterBottomSheetContent items={items} />, { ariaLabel: "대피소 목록" });
+      setContent(<ShelterBottomSheetContent items={items} />, "대피소 목록");
       openedOnceRef.current = true;
     }
-  }, [isLoaded, position, shelters, sheltersError, open]);
+  }, [isLoaded, shelters, sheltersError, setContent]);
 
   return {
     openedOnceRef

--- a/src/features/map/hooks/useShelterButtonInteraction.ts
+++ b/src/features/map/hooks/useShelterButtonInteraction.ts
@@ -10,34 +10,26 @@ export function useShelterButtonInteraction(
   shelters: NearbyShelterApiItem[] | null,
   sheltersError: string | null
 ) {
-  const isOpen = useBottomSheetStore(state => state.isOpen);
+  const content = useBottomSheetStore(state => state.content);
   const translateY = useBottomSheetStore(state => state.translateY);
   const expandToTop = useBottomSheetStore(state => state.expandToTop);
   const collapseToBottom = useBottomSheetStore(state => state.collapseToBottom);
-  const openAndExpand = useBottomSheetStore(state => state.openAndExpand);
-  const setTranslateY = useBottomSheetStore(state => state.setTranslateY);
+  const setContent = useBottomSheetStore(state => state.setContent);
 
   const handleShelterClick = () => {
-    if (!isOpen) {
+    if (!content) {
       if (sheltersError) {
-        openAndExpand(createElement(ShelterBottomSheetContent, { error: sheltersError }), {
-          ariaLabel: "대피소 목록"
-        });
+        setContent(
+          createElement(ShelterBottomSheetContent, { error: sheltersError }),
+          "대피소 목록"
+        );
       } else if (shelters && Array.isArray(shelters)) {
         const items = Array.isArray(shelters) ? shelters : [];
-        openAndExpand(createElement(ShelterBottomSheetContent, { items }), {
-          ariaLabel: "대피소 목록"
-        });
+        setContent(createElement(ShelterBottomSheetContent, { items }), "대피소 목록");
       } else {
-        openAndExpand(createElement(ShelterBottomSheetContent, { items: [] }), {
-          ariaLabel: "대피소 목록"
-        });
+        setContent(createElement(ShelterBottomSheetContent, { items: [] }), "대피소 목록");
       }
 
-      // 확실하게 translateY를 0으로 설정
-      setTimeout(() => {
-        setTranslateY(0);
-      }, 50);
       return;
     }
 

--- a/src/features/shelter/components/ShelterBottomSheetContent.tsx
+++ b/src/features/shelter/components/ShelterBottomSheetContent.tsx
@@ -13,10 +13,15 @@ export function ShelterBottomSheetContent({
   error?: string | null;
 }) {
   const navigate = useNavigate();
-  const { close } = useBottomSheetStore();
+  useBottomSheetStore();
 
   const handlePress = (shelter: NearbyShelterApiItem) => {
-    close();
+    useBottomSheetStore.setState({
+      content: null,
+      ariaLabel: null,
+      expandToTop: null,
+      collapseToBottom: null
+    });
     const query = encodeURIComponent(JSON.stringify(shelter));
     navigate(`/detail?shelter=${query}`);
   };


### PR DESCRIPTION
## #️⃣연관된 이슈
close #40
> ex) #이슈번호, #이슈번호

## 📝작업 내용
- `BottomSheet` 전역(App) 렌더링 제거 → `Map` 내부에서만 렌더
- 초기 진입 시 바텀시트가 보이지 않던 이슈 해결
  - 초기 “빈 리스트” 노출 로직을 별도 이펙트로 분리해 1회 보장
  - 지도 로드 후(`isLoaded`)에만 데이터/에러 업데이트 수행
- 불필요한 백드롭 기능 제거 (레이아웃은 유지)
  - `BottomSheetView`의 `onBackdropClick` 제거
  - `BottomSheet.tsx`에서 백드롭 핸들러 제거
- 바텀시트의 수동 DOM transform 제거, 상태 동기화 단순화
- 지도 로드 전에도 `Map` 컴포넌트는 렌더되도록 수정 (GoogleMap만 조건부 렌더)

### 바텀시트가 초기 진입 시 정상 작동 하지 않았던 원인 추정
- Map이 !isLoaded일 때 전체 컴포넌트 조기 반환 → 바텀시트 마운트 전 setContent 호출 무효.
- 초기 “빈 리스트” 분기가 isLoaded 가드에 막혀 실행 누락. (얼리 리턴)
- 전역(App) 렌더링으로 라우트/수명주기와 불일치, 초기화 타이밍 충돌.
- 불필요한 백드롭/수동 transform 로직이 사이드이펙트 유발 여지.

### 상세 내용
- 렌더 조건 정리
  - `BottomSheet`는 `useBottomSheetStore.content`가 있을 때만 포털로 렌더
  - 초기 진입 시 `position`이 없더라도 한 번은 빈 리스트를 노출
  - 이후 `isLoaded === true`가 되면 shelters 데이터/에러로 업데이트
- 백드롭 제거
  - 사용성 요구에 따라 백드롭 클릭으로 닫는 동작을 완전히 제거
  - 스타일은 유지하여 레이아웃 붕괴 방지

### 고려 사항
- 전역에서 바텀시트를 사용하던 케이스는 없어졌으므로, 이후 다른 화면에서 필요 시 각 화면에서 직접 렌더 필요

### 리스크/영향 범위
- 전역에서 바텀시트를 가정한 코드가 있었다면 동작 변경 가능성(현재 없음)
